### PR TITLE
ツイート一覧

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -52,10 +52,10 @@ class TweetController extends Controller
      * 
      * @return View
      */
-    public function getAll(): View
+    public function getAllTweets(): View
     {
-       $tweets = $this->tweetModel->getAllTweet();
+       $tweets = $this->tweetModel->getAllTweets();
 
        return view('tweet.index', compact('tweets'));
-    }    
+    }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -47,5 +47,15 @@ class TweetController extends Controller
         
     }
 
-    
+    /**
+     * ツイート一覧を表示する
+     * 
+     * @return View
+     */
+    public function getAll(): View
+    {
+       $tweets = $this->tweetModel->getAll();
+
+       return view('tweet.index', compact('tweets'));
+    }    
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -43,7 +43,7 @@ class TweetController extends Controller
         $tweetParam = $request->validated();
         $this->tweetModel->store($tweetParam, $userId);
 
-        return redirect()->route('home')->with('success', 'ツイートされました');
+        return redirect()->route('tweet.index')->with('success', 'ツイートが保存されました');
         
     }
 
@@ -54,7 +54,7 @@ class TweetController extends Controller
      */
     public function getAll(): View
     {
-       $tweets = $this->tweetModel->getAll();
+       $tweets = $this->tweetModel->getAllTweet();
 
        return view('tweet.index', compact('tweets'));
     }    

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -22,7 +22,7 @@ class TweetController extends Controller
     }
 
     /**
-     * ツイート投稿画面を表示するViewを返す
+     * ツイート投稿画面を表示する
      *  
      * @return View
      */

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -81,9 +81,9 @@ class UserController extends Controller
      * 
      * @return View
      */
-    public function getAll(): View
+    public function getAllUsers(): View
     {
-        $users = $this->userModel->getAllUser();
+        $users = $this->userModel->getAllUsers();
 
         return view('user.index', compact('users'));
     }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -21,7 +21,7 @@ class UserController extends Controller
     }
 
     /**
-     * ユーザーIDに基づいてユーザーを検索し、ユーザー情報を表示するビューを返す
+     * ユーザーIDに基づいてユーザーを検索し、ユーザー情報を表示する
      * 
      * @param int $userId ユーザーID
      * @return View
@@ -34,7 +34,7 @@ class UserController extends Controller
     }
 
     /**
-     * ユーザー編集画面を表示するViewを返す
+     * ユーザー編集画面を表示する
      * 
      * @return View
      */
@@ -77,7 +77,7 @@ class UserController extends Controller
     }
 
     /**
-     * ユーザー一覧を表示するViewを返す
+     * ユーザー一覧を表示する
      * 
      * @return View
      */

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -33,7 +33,7 @@ class Tweet extends Model
      * 
      * @return Collection
      */
-    public function getAll(): Collection
+    public function getAllTweet(): Collection
     {
         return Tweet::latest()->get();
     }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Tweet extends Model
 {
@@ -25,5 +28,24 @@ class Tweet extends Model
         $this->save();
     }
 
+    /**
+     * 全てのツイートを最新順で取得する
+     * 
+     * @return Collection
+     */
+    public function getAll(): Collection
+    {
+        return Tweet::latest()->get();
+    }
+
+    /**
+     * リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -33,7 +33,7 @@ class Tweet extends Model
      * 
      * @return Collection
      */
-    public function getAllTweet(): Collection
+    public function getAllTweets(): Collection
     {
         return Tweet::latest()->get();
     }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -97,7 +97,7 @@ class User extends Authenticatable
      * 
      * @return Collection
      */
-    public function getAllUser(): Collection
+    public function getAllUsers(): Collection
     {
         return User::all();
     }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -10,6 +10,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -99,5 +100,15 @@ class User extends Authenticatable
     public function getAllUser(): Collection
     {
         return User::all();
+    }
+
+    /**
+     * リレーション
+     * 
+     * @return HasMany
+     */
+    public function tweets() : HasMany
+    {
+        return $this->hasMany(Tweet::class);
     }
 }

--- a/twitter/resources/views/layouts/app.blade.php
+++ b/twitter/resources/views/layouts/app.blade.php
@@ -20,7 +20,7 @@
     <div id="app">
         <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
             <div class="container">
-                <a class="navbar-brand" href="{{ url('/') }}">
+                <a class="navbar-brand" href="{{ url('/tweets') }}">
                     {{ config('app.name', 'Laravel') }}
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">

--- a/twitter/resources/views/layouts/app.blade.php
+++ b/twitter/resources/views/layouts/app.blade.php
@@ -50,6 +50,9 @@
                             @endif
                         @else
                         <li class="nav-item">    
+                            <a class="nav-link" href="{{ route('tweet.index') }}">{{ __('ホーム') }}</a>
+                        </li>
+                        <li class="nav-item">    
                             <a class="nav-link" href="{{ route('tweet.create') }}">{{ __('ツイート') }}</a>
                         </li>
                             <li class="nav-item dropdown">

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            @foreach($tweets as $tweet)
+            <div class="card bg-white mb-3">
+                <div class="card-body">
+                    <h6 class="card-title">
+                        {{ $tweet->user->display_name }}
+                        <span class="text-muted">{{ '@' }}{{ $tweet->user->user_name }}</span>
+                        <span class="text-muted">{{ '・' }}{{ $tweet->created_at->format('h:i A · M d, Y') }}</span>
+                    </h6>
+                    <p class="card-text">
+                        {{ $tweet->body }}
+                    </p>
+                </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endsection

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -4,6 +4,11 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
+            @if (session('success'))
+                <div class="alert alert-success" role="alert">
+                    {{ session('success') }}
+                </div>
+            @endif
             @foreach($tweets as $tweet)
             <div class="card bg-white mb-3">
                 <div class="card-body">

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -42,5 +42,9 @@ Route::get('/users', [UserController::class, 'getAll'])->name('user.index');
 Route::prefix('tweet')->group(function() {
     // ツイート画面の表示
     Route::get('/create', [TweetController:: class, 'create'])->name('tweet.create');
+    // ツイート保存
     Route::post('/store', [TweetController:: class, 'store'])->name('tweet.store');
 });
+
+// ツイート一覧
+Route::get('/tweets', [TweetController:: class, 'getAll'])->name('tweet.index');


### PR DESCRIPTION
# 課題のリンク
- ツイート一覧が見られる

# 改修内容
- tweet/index.blade.phpを作成
- ヘッダーのTwitter Clone・ホームからツイート一覧に遷移
- TweetコントローラーにgetAllメソッドを作成
- TweetモデルにgetAllTweetメソッドを作成しすべてのツイートを降順取得
- リレーションを追加

# キャプチャ
<img width="1350" alt="スクリーンショット 2023-09-14 11 04 47" src="https://github.com/JoMashiko/twitter-clone/assets/143980390/bb3940a1-3c0a-4bf2-977b-2955e9c2e076">

# 検証内容
- Tweersテーブルに存在するツイートが表示されていることを目視で確認