### PR TITLE
ツイート編集・削除機能

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -69,7 +69,7 @@ class TweetController extends Controller
     public function findByTweetId(int $tweetId): View
     {
         $tweet = $this->tweetModel->findByTweetId($tweetId);
-
+    
         return view('tweet.show', compact('tweet'));
     }
 
@@ -100,5 +100,19 @@ class TweetController extends Controller
         $tweet->updateTweet($tweetParam, $tweet);
 
         return redirect()->route('tweet.show', $tweetId)->with('success', '更新しました');
-    } 
+    }
+
+    /**
+     * ツイートを削除する
+     * 
+     * @param int $tweetId ユーザーID
+     * @return RedirectResponse
+     */
+    public function delete(int $tweetId): RedirectResponse
+    {
+        $user = $this->tweetModel->findByTweetId($tweetId);
+        $user->deleteTweet();
+
+        return redirect()->route('tweet.index')->with('success', 'ツイートを削除しました');
+    }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Tweet\UpdateRequest;
+use Exception;
 
 class TweetController extends Controller
 {
@@ -66,11 +67,16 @@ class TweetController extends Controller
      * @param int $tweetId
      * @return View
      */
-    public function findByTweetId(int $tweetId): View
-    {
-        $tweet = $this->tweetModel->findByTweetId($tweetId);
-    
-        return view('tweet.show', compact('tweet'));
+    public function findByTweetId(int $tweetId)
+    {   
+        try{
+            $tweet = $this->tweetModel->findByTweetId($tweetId);
+            return view('tweet.show', compact('tweet'));
+        }
+        catch(Exception $e){
+            logger($e);
+            return redirect()->route('tweet.index')->with('message', 'ツイートが見つかりませんでした');
+        }
     }
 
     /**

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -97,6 +97,7 @@ class TweetController extends Controller
     {
         $tweetParam = $request->validated();
         $tweet = $this->tweetModel->findByTweetId($tweetId);
+        $this->authorize('update', $tweet);
         $tweet->updateTweet($tweetParam, $tweet);
 
         return redirect()->route('tweet.show', $tweetId)->with('success', '更新しました');

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Tweet\UpdateRequest;
 
 class TweetController extends Controller
 {
@@ -71,4 +72,33 @@ class TweetController extends Controller
 
         return view('tweet.show', compact('tweet'));
     }
+
+    /**
+     * ツイート編集画面を表示する
+     * 
+     * @param int $tweetId
+     * @return View
+     */
+    public function edit(int $tweetId): View
+    {
+        $tweet = $this->tweetModel->findByTweetId($tweetId);
+
+        return view('tweet.edit',compact('tweet'));
+    }
+
+    /**
+     * ツイートを更新する
+     * 
+     * @param UpdateRequest $request
+     * @param int $tweetId
+     * @return RedirectResponse
+     */
+    public function update(UpdateRequest $request, int $tweetId): RedirectResponse
+    {
+        $tweetParam = $request->validated();
+        $tweet = $this->tweetModel->findByTweetId($tweetId);
+        $tweet->updateTweet($tweetParam, $tweet);
+
+        return redirect()->route('tweet.show', $tweetId)->with('success', '更新しました');
+    } 
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -3,12 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Tweet\CreateTweetRequest;
+use App\Http\Requests\Tweet\UpdateRequest;
 use App\Models\Tweet;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use App\Http\Requests\Tweet\UpdateRequest;
 use Exception;
 use Illuminate\Support\Facades\Log;
 
@@ -42,13 +42,13 @@ class TweetController extends Controller
      */
     public function store(CreateTweetRequest $request): RedirectResponse
     {
-        try{
+        try {
             $userId = Auth::id();
             $tweetParam = $request->validated();
             $this->tweetModel->store($tweetParam, $userId);
 
             return redirect()->route('tweet.index')->with('success', 'ツイートが保存されました');
-        }catch(Exception $e){
+        } catch (Exception $e) {
             Log::error($e);
 
             return redirect()->route('tweet.index')->with('message', 'ツイートできませんでした');
@@ -62,9 +62,9 @@ class TweetController extends Controller
      */
     public function getAllTweets(): View
     {
-       $tweets = $this->tweetModel->getAllTweets();
+        $tweets = $this->tweetModel->getAllTweets();
 
-       return view('tweet.index', compact('tweets'));
+        return view('tweet.index', compact('tweets'));
     }
 
     /**
@@ -74,13 +74,12 @@ class TweetController extends Controller
      * @return View
      */
     public function findByTweetId(int $tweetId)
-    {   
-        try{
+    {
+        try {
             $tweet = $this->tweetModel->findByTweetId($tweetId);
 
             return view('tweet.show', compact('tweet'));
-        }
-        catch(Exception $e){
+        } catch (Exception $e) {
             Log::error($e);
 
             return redirect()->route('tweet.index')->with('message', 'ツイートが見つかりませんでした');
@@ -97,7 +96,7 @@ class TweetController extends Controller
     {
         $tweet = $this->tweetModel->findByTweetId($tweetId);
 
-        return view('tweet.edit',compact('tweet'));
+        return view('tweet.edit', compact('tweet'));
     }
 
     /**
@@ -109,14 +108,14 @@ class TweetController extends Controller
      */
     public function update(UpdateRequest $request, int $tweetId): RedirectResponse
     {
-        try{
+        try {
             $tweetParam = $request->validated();
             $tweet = $this->tweetModel->findByTweetId($tweetId);
             $this->authorize('update', $tweet);
             $tweet->updateTweet($tweetParam, $tweet);
 
             return redirect()->route('tweet.show', $tweetId)->with('success', '更新しました');
-        }catch(Exception $e){
+        } catch (Exception $e) {
             Log::error($e);
 
             return redirect()->route('tweet.show', $tweetId)->with('message', '更新に失敗しました');
@@ -131,12 +130,12 @@ class TweetController extends Controller
      */
     public function delete(int $tweetId): RedirectResponse
     {
-        try{
+        try {
             $user = $this->tweetModel->findByTweetId($tweetId);
             $user->deleteTweet();
-    
+
             return redirect()->route('tweet.index')->with('success', 'ツイートを削除しました');
-        }catch(Exception $e){
+        } catch (Exception $e) {
             Log::error($e);
 
             return redirect()->route('tweet.index')->with('message', 'ツイートを削除に失敗しました');

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -48,7 +48,7 @@ class UserController extends Controller
     /**
      * 更新内容を受け取り、ユーザー情報を更新する
      * 
-     * @param  UserRequest  $request
+     * @param  UpdateRequest  $request
      * @param  int $userId ユーザーID
      * @return RedirectResponse
      */

--- a/twitter/app/Http/Requests/Tweet/UpdateRequest.php
+++ b/twitter/app/Http/Requests/Tweet/UpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Tweet;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'body' => 'required|string|max:140'
+        ];
+    }
+}

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -71,4 +71,12 @@ class Tweet extends Model
         $tweet->fill($tweetParam);
         $tweet->update();
     }
+
+    /**
+     * ユーザーを削除する
+     */
+    public function deleteTweet(): void
+    {
+        $this->delete();
+    }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Arr;
 
 class Tweet extends Model
 {
@@ -57,5 +58,17 @@ class Tweet extends Model
     public function findByTweetId(int $tweetId): Tweet
     {
         return Tweet::find($tweetId);
+    }
+
+    /**
+     * ツイートを更新する
+     * 
+     * @param array $tweetPram
+     * @param Tweet $tweet
+     */
+    public function updateTweet(array $tweetParam, Tweet $tweet): void
+    {
+        $tweet->fill($tweetParam);
+        $tweet->save();
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -57,7 +57,7 @@ class Tweet extends Model
      */
     public function findByTweetId(int $tweetId): Tweet
     {
-        return Tweet::find($tweetId);
+        return Tweet::findOrFail($tweetId);
     }
 
     /**

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -69,6 +69,6 @@ class Tweet extends Model
     public function updateTweet(array $tweetParam, Tweet $tweet): void
     {
         $tweet->fill($tweetParam);
-        $tweet->save();
+        $tweet->update();
     }
 }

--- a/twitter/app/Policies/TweetPolicy.php
+++ b/twitter/app/Policies/TweetPolicy.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tweet;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TweetPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tweet  $tweet
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Tweet $tweet)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tweet  $tweet
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Tweet $tweet)
+    {
+        return $user->id === $tweet->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tweet  $tweet
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Tweet $tweet)
+    {
+        return $user->id === $tweet->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tweet  $tweet
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function restore(User $user, Tweet $tweet)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tweet  $tweet
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function forceDelete(User $user, Tweet $tweet)
+    {
+        //
+    }
+}

--- a/twitter/resources/views/tweet/edit.blade.php
+++ b/twitter/resources/views/tweet/edit.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('編集') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('tweet.update', $tweet) }}">
+
+                        @csrf
+                        @method('put')
+
+                        <div class="mb-3">
+                            <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') ?? $tweet->body }}" required autofocus></textarea>
+                            
+                            @error('body')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                             @enderror
+                        </div>
+
+                        <div class="d-grid justify-content-md-end">
+                            <button class="btn btn-primary" type="submit">{{ __('保存') }}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -9,6 +9,11 @@
                     {{ session('success') }}
                 </div>
             @endif
+            @if (session('message'))
+                <div class="alert alert-success" role="alert">
+                    {{ session('message') }}
+                </div>
+            @endif
             @foreach($tweets as $tweet)
             <div class="card bg-white mb-3">
                 <a href="{{ route('tweet.show', $tweet->id) }}" class="card-body" style="text-decoration: none; color: inherit;">

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -9,6 +9,11 @@
                     {{ session('success') }}
                 </div>
             @endif
+            @if(session('message'))
+                <div class="alert alert-success">
+                    {{ session('message') }}
+                </div>
+            @endif
             <div class="card bg-white mb-3">
                 <div class="card-body">
                     <h6 class="card-title">

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -4,6 +4,11 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
+            @if(session('success'))
+                <div class="alert alert-success">
+                    {{ session('success') }}
+                </div>
+            @endif
             <div class="card bg-white mb-3">
                 <div class="card-body">
                     <h6 class="card-title">
@@ -14,6 +19,19 @@
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
+                    <div class="d-grid d-md-flex justify-content-md-end">
+                        <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
+                            {{ __('編集') }}
+                        </button>
+                        <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
+                        return confirm('本当にツイートを削除してもよろしいですか？');">
+                            @csrf
+                            @method('delete')
+                            <button type="submit" class="btn btn-danger mx-2">
+                                {{ __('削除') }}
+                            </button>
+                        </form>
+                      </div>
                 </div>
             </div>
         </div>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -19,19 +19,21 @@
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
-                    <div class="d-grid d-md-flex justify-content-md-end">
-                        <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
-                            {{ __('編集') }}
-                        </button>
-                        <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
-                        return confirm('本当にツイートを削除してもよろしいですか？');">
-                            @csrf
-                            @method('delete')
-                            <button type="submit" class="btn btn-danger mx-2">
-                                {{ __('削除') }}
+                    @can('update', $tweet)
+                        <div class="d-grid d-md-flex justify-content-md-end">
+                            <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
+                                {{ __('編集') }}
                             </button>
-                        </form>
-                      </div>
+                            <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
+                            return confirm('本当にツイートを削除してもよろしいですか？');">
+                                @csrf
+                                @method('delete')
+                                <button type="submit" class="btn btn-danger mx-2">
+                                    {{ __('削除') }}
+                                </button>
+                            </form>
+                        </div>
+                    @endcan
                 </div>
             </div>
         </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -23,29 +23,33 @@ Auth::routes();
 
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
-// マイページ
-Route::prefix('user/{id}')->group(function() {
-    // ユーザー詳細画面の表示
-    Route::get('/', [UserController::class, 'findByUserId'])->name('user.show');
-    // ユーザー編集画面の表示
-    Route::get('/edit', [UserController::class, 'edit'])->name('user.edit');
-    // ユーザー情報更新
-    Route::put('/update', [UserController::class, 'update'])->name('user.update');
-    // ユーザー削除
-    Route::delete('/', [UserController::class, 'delete'])->name('user.delete');
-});
+// 認証済み
+Route::group(['middleware' => 'auth'], function () {
 
-// ユーザー一覧
-Route::get('/users', [UserController::class, 'getAllUsers'])->name('user.index');
+    // マイページ
+    Route::prefix('user/{id}')->group(function() {
+        // ユーザー詳細画面の表示
+        Route::get('/', [UserController::class, 'findByUserId'])->name('user.show');
+        // ユーザー編集画面の表示
+        Route::get('/edit', [UserController::class, 'edit'])->name('user.edit');
+        // ユーザー情報更新
+        Route::put('/update', [UserController::class, 'update'])->name('user.update');
+        // ユーザー削除
+        Route::delete('/', [UserController::class, 'delete'])->name('user.delete');
+    });
 
-// ツイート
-Route::prefix('tweet')->group(function() {
-    // ツイート画面の表示
-    Route::get('/create', [TweetController:: class, 'create'])->name('tweet.create');
-    // ツイート保存
-    Route::post('/store', [TweetController:: class, 'store'])->name('tweet.store');
-    // ツイート詳細画面の表示
-    Route::get('/{id}', [TweetController:: class, 'findByTweetId'])->name('tweet.show');
+    // ユーザー一覧
+    Route::get('/users', [UserController::class, 'getAllUsers'])->name('user.index');
+
+    // ツイート
+    Route::prefix('tweet')->group(function() {
+        // ツイート画面の表示
+        Route::get('/create', [TweetController:: class, 'create'])->name('tweet.create');
+        // ツイート保存
+        Route::post('/store', [TweetController:: class, 'store'])->name('tweet.store');
+        // ツイート詳細画面の表示
+        Route::get('/{id}', [TweetController:: class, 'findByTweetId'])->name('tweet.show');
+    });
 });
 
 // ツイート一覧

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -49,6 +49,12 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/store', [TweetController:: class, 'store'])->name('tweet.store');
         // ツイート詳細画面の表示
         Route::get('/{id}', [TweetController:: class, 'findByTweetId'])->name('tweet.show');
+        //　ツイート編集画面の表示
+        Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('tweet.edit');
+        // ツイート内容更新
+        Route::put('/{id}/update', [TweetController::class, 'update'])->name('tweet.update');
+        // ツイート削除
+        Route::delete('/{id}/delete', [TweetController::class, 'delete'])->name('tweet.delete');
     });
 });
 


### PR DESCRIPTION
# 課題のリンク
- ツイートの編集ができる
- ツイートを削除できる 

# 改修内容
- ツイート詳細画面に編集・削除ボタンを追加
- TweetPolicyを作成
- $user->id === $tweet->user_id の場合のみ編集・削除ボタンを表示
- web.phpに 'middleware' => 'auth' を追加

# キャプチャ

https://github.com/JoMashiko/twitter-clone/assets/143980390/9cbdbe9e-e28f-413f-a1b5-cecec56f0da7


# 検証内容
- tweetsテーブルが編集・削除されていることを目視で確認