### PR TITLE
フォロー・フォロワー一覧機能

### DIFF
--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -116,4 +116,28 @@ class UserController extends Controller
 
         return redirect()->route('user.index');
     }
+
+    /**
+     * フォロー一覧を表示する
+     *
+     * @return View
+     */
+    public function getAllFollowedUsers(): View
+    {
+        $followedUsers = Auth::user()->following;
+
+        return view('user.followed', compact('followedUsers'));
+    }
+
+    /**
+     * フォロワー一覧を表示する
+     *
+     * @return View
+     */
+    public function getAllFollowerUsers(): View
+    {
+        $followerUsers = Auth::user()->followers;
+
+        return view('user.follower', compact('followerUsers'));
+    }
 }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -122,7 +122,7 @@ class UserController extends Controller
      *
      * @return View
      */
-    public function getAllFollowedUsers(): View
+    public function showFollowedUsers(): View
     {
         $followedUsers = Auth::user()->following;
 
@@ -134,7 +134,7 @@ class UserController extends Controller
      *
      * @return View
      */
-    public function getAllFollowerUsers(): View
+    public function showFollowerUsers(): View
     {
         $followerUsers = Auth::user()->followers;
 

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -29,11 +29,13 @@ class UserController extends Controller
      * @param int $userId ユーザーID
      * @return View
      */
-    public function findByUserId(int $userId): View
+    public function showUserInfo(int $userId): View
     {
         $user = $this->userModel->findByUserId($userId);
+        $followedCount = $this->followerModel->countFollowedUsers($user);
+        $followerCount = $this->followerModel->countFollowerUsers($user);
 
-        return view('user.show', compact('user'));
+        return view('user.show', compact('user', 'followedCount', 'followerCount'));
     }
 
     /**
@@ -118,7 +120,7 @@ class UserController extends Controller
     }
 
     /**
-     * フォロー一覧を表示する
+     * ログインユーザーのフォロー一覧を表示する
      *
      * @return View
      */
@@ -130,7 +132,7 @@ class UserController extends Controller
     }
 
     /**
-     * フォロワー一覧を表示する
+     * ログインユーザーのフォロワー一覧を表示する
      *
      * @return View
      */

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -81,4 +81,26 @@ class Follower extends Model
             ['followed_id', $targetUserId],
         ])->exists();
     }
+
+    /**
+     * フォローの数をカウントする
+     *
+     * @param User $user
+     * @return integer
+     */
+    public function countFollowedUsers(User $user): int
+    {
+        return $user->following()->count();
+    }
+
+    /**
+     * フォロワーの数をカウントする
+     *
+     * @param User $user
+     * @return integer
+     */
+    public function countFollowerUsers(User $user): int
+    {
+        return $user->followers()->count();
+    }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Auth;
 
 class Follower extends Model
@@ -19,11 +21,11 @@ class Follower extends Model
     /**
      * リレーション(followersテーブルのfollowing_idとusersテーブルのidを紐付ける)
      *
-     * @return BelongsTo
+     * @return belongsToMany
      */
-    public function followingUser(): BelongsTo
+    public function followingUsers(): belongsToMany
     {
-        return $this->belongsTo(User::class, 'following_id', 'id');
+        return $this->belongsToMany(User::class);
     }
 
     /**

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -19,7 +19,7 @@ class Follower extends Model
     public $timestamps = false;
 
     /**
-     * リレーション(followersテーブルのfollowing_idとusersテーブルのidを紐付ける)
+     * リレーション
      *
      * @return belongsToMany
      */
@@ -29,13 +29,13 @@ class Follower extends Model
     }
 
     /**
-     * リレーション(followersテーブルのfollowed_idとusersテーブルのidを紐付ける)
+     * リレーション
      *
-     * @return BelongsTo
+     * @return belongsToMany
      */
-    public function followedUser(): BelongsTo
+    public function followedUser(): belongsToMany
     {
-        return $this->belongsTo(User::class, 'followed_id', 'id');
+        return $this->belongsToMany(User::class);
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
 use Illuminate\Http\RedirectResponse;
 
 class User extends Authenticatable
@@ -113,22 +115,22 @@ class User extends Authenticatable
     }
 
     /**
-     * リレーション(usersテーブルのidとfollowersテーブルのfollowing_idを紐付ける)
+     * フォローしているユーザーとの多対多のリレーション(フォローしているユーザーの取得)
      *
-     * @return HasMany
+     * @return BelongsToMany
      */
-    public function follows(): HasMany
+    public function following(): BelongsToMany
     {
-        return $this->hasmany(Follower::class, 'following_id', 'id');
+        return $this->belongsToMany(User::class, 'followers', 'following_id', 'followed_id');
     }
 
     /**
-     * リレーション(usersテーブルのidとfollowersテーブルのfollowed_idを紐付ける)
+     * このユーザーをフォローしているユーザーとの多対多のリレーション(フォロワーの取得)
      *
-     * @return HasMany
+     * @return BelongsToMany
      */
-    public function followers(): HasMany
+    public function followers(): BelongsToMany
     {
-        return $this->hasmany(Follower::class, 'followed_id', 'id');
+        return $this->belongsToMany(User::class, 'followers', 'followed_id', 'following_id');
     }
 }

--- a/twitter/resources/views/layouts/app.blade.php
+++ b/twitter/resources/views/layouts/app.blade.php
@@ -69,6 +69,14 @@
                                         {{ __('ユーザー一覧') }}
                                     </button>
 
+                                    <button type="button" class="dropdown-item" onclick="location.href='{{ route('user.followed') }}'">
+                                        {{ __('フォロー一覧') }}
+                                    </button>
+
+                                    <button type="button" class="dropdown-item" onclick="location.href='{{ route('user.follower') }}'">
+                                        {{ __('フォロワー一覧') }}
+                                    </button>
+
                                     <button type="button" class="dropdown-item" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                                         {{ __('ログアウト') }}
                                     </button>

--- a/twitter/resources/views/layouts/app.blade.php
+++ b/twitter/resources/views/layouts/app.blade.php
@@ -69,14 +69,6 @@
                                         {{ __('ユーザー一覧') }}
                                     </button>
 
-                                    <button type="button" class="dropdown-item" onclick="location.href='{{ route('user.followed') }}'">
-                                        {{ __('フォロー一覧') }}
-                                    </button>
-
-                                    <button type="button" class="dropdown-item" onclick="location.href='{{ route('user.follower') }}'">
-                                        {{ __('フォロワー一覧') }}
-                                    </button>
-
                                     <button type="button" class="dropdown-item" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                                         {{ __('ログアウト') }}
                                     </button>

--- a/twitter/resources/views/user/followed.blade.php
+++ b/twitter/resources/views/user/followed.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">フォロー一覧</div>
+                <div class="card-body">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>名前</th>
+                                <th>メールアドレス</th>
+                                <th>ユーザー名</th>
+                                <th>登録日</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($followedUsers as $user)
+                                <tr>
+                                    <td>{{ $user->id }}</td>
+                                    <td>{{ $user->display_name }}</td>
+                                    <td>{{ $user->email }}</td>
+                                    <td>{{ $user->user_name }}</td>
+                                    <td>{{ $user->created_at }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/twitter/resources/views/user/followed.blade.php
+++ b/twitter/resources/views/user/followed.blade.php
@@ -15,6 +15,7 @@
                                 <th>メールアドレス</th>
                                 <th>ユーザー名</th>
                                 <th>登録日</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -25,6 +26,26 @@
                                     <td>{{ $user->email }}</td>
                                     <td>{{ $user->user_name }}</td>
                                     <td>{{ $user->created_at }}</td>
+                                    <td>
+                                        @can('followOrUnfollow', $user)
+                                        <form method="POST" action="{{ route('user.follow', $user) }}">
+                                            @csrf
+                                            @can('follow', $user)
+                                                <button type="submit" class="btn btn-outline-dark me-md-2">
+                                                    {{ __('Follow') }}
+                                                </button>
+                                            @endcan
+                                        </form>
+                                        <form method="POST" action="{{ route('user.unfollow', $user) }}">
+                                            @csrf
+                                            @can('unfollow', $user)
+                                                <button type="submit" class="btn btn-outline-dark me-md-2">
+                                                    {{ __('UnFollow') }}
+                                                </button>
+                                            @endcan
+                                        </form>
+                                        @endcan
+                                    </td>
                                 </tr>
                             @endforeach
                         </tbody>

--- a/twitter/resources/views/user/follower.blade.php
+++ b/twitter/resources/views/user/follower.blade.php
@@ -15,6 +15,7 @@
                                 <th>メールアドレス</th>
                                 <th>ユーザー名</th>
                                 <th>登録日</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -25,6 +26,26 @@
                                     <td>{{ $user->email }}</td>
                                     <td>{{ $user->user_name }}</td>
                                     <td>{{ $user->created_at }}</td>
+                                    <td>
+                                        @can('followOrUnfollow', $user)
+                                        <form method="POST" action="{{ route('user.follow', $user) }}">
+                                            @csrf
+                                            @can('follow', $user)
+                                                <button type="submit" class="btn btn-outline-dark me-md-2">
+                                                    {{ __('Follow') }}
+                                                </button>
+                                            @endcan
+                                        </form>
+                                        <form method="POST" action="{{ route('user.unfollow', $user) }}">
+                                            @csrf
+                                            @can('unfollow', $user)
+                                                <button type="submit" class="btn btn-outline-dark me-md-2">
+                                                    {{ __('UnFollow') }}
+                                                </button>
+                                            @endcan
+                                        </form>
+                                        @endcan
+                                    </td>
                                 </tr>
                             @endforeach
                         </tbody>

--- a/twitter/resources/views/user/follower.blade.php
+++ b/twitter/resources/views/user/follower.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">フォロワー一覧</div>
+                <div class="card-body">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>名前</th>
+                                <th>メールアドレス</th>
+                                <th>ユーザー名</th>
+                                <th>登録日</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($followerUsers as $user)
+                                <tr>
+                                    <td>{{ $user->id }}</td>
+                                    <td>{{ $user->display_name }}</td>
+                                    <td>{{ $user->email }}</td>
+                                    <td>{{ $user->user_name }}</td>
+                                    <td>{{ $user->created_at }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -26,8 +26,8 @@
                                     <td>{{ $user->email }}</td>
                                     <td>{{ $user->user_name }}</td>
                                     <td>{{ $user->created_at }}</td>
-                                    @can('followOrUnfollow', $user)
                                     <td>
+                                        @can('followOrUnfollow', $user)
                                         <form method="POST" action="{{ route('user.follow', $user) }}">
                                             @csrf
                                             @can('follow', $user)
@@ -44,8 +44,8 @@
                                                 </button>
                                             @endcan
                                         </form>
+                                        @endcan
                                     </td>
-                                    @endcan
                                 </tr>
                             @endforeach
                         </tbody>

--- a/twitter/resources/views/user/show.blade.php
+++ b/twitter/resources/views/user/show.blade.php
@@ -23,9 +23,16 @@
                     <p>{{ __('誕生日: ') . $user->birthday }}</p>
                     <p>{{ __('ユーザーネーム: ') . $user->user_name }}</p>
                     <p>{{ __('自己紹介: ') . $user->bio_text }}</p>
+                   <p>
+                        <a href="{{ route('user.followed') }}">
+                            {{ $followedCount }} 
+                            <span style="margin-right: 10px">Following</span>
+                        </a>
+                        <a href="{{ route('user.follower') }}">{{ $followerCount }} Follower</a>
+                    </p>
                         
-                    <div class="d-flex">
-                        <button type="button" class="btn btn-dark" onclick="location.href='{{ route('user.edit', $user) }}'">
+                    <div class="d-flex d-grid justify-content-md-end">
+                        <button type="button" class="btn btn-outline-dark" onclick="location.href='{{ route('user.edit', $user) }}'">
                             {{ __('編集') }}
                         </button>
                         <form method='post' action={{ route('user.delete', $user) }} onsubmit="

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -30,7 +30,7 @@ Route::group(['middleware' => 'auth'], function () {
     // マイページ
     Route::prefix('user/{id}')->group(function () {
         // ユーザー詳細画面の表示
-        Route::get('/', [UserController::class, 'findByUserId'])->name('user.show');
+        Route::get('/', [UserController::class, 'showUserInfo'])->name('user.show');
         // ユーザー編集画面の表示
         Route::get('/edit', [UserController::class, 'edit'])->name('user.edit');
         // ユーザー情報更新

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -39,12 +39,18 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('/', [UserController::class, 'delete'])->name('user.delete');
     });
 
-    // ユーザー一覧
-    Route::get('/users', [UserController::class, 'getAllUsers'])->name('user.index');
-    // フォロー
-    Route::post('users/follow/{id}', [UserController::class, 'follow'])->name('user.follow');
-    // フォロー解除
-    Route::post('users/unfollow/{id}', [UserController::class, 'unfollow'])->name('user.unfollow');
+    Route::prefix('users')->group(function () {
+        // ユーザー一覧
+        Route::get('/', [UserController::class, 'getAllUsers'])->name('user.index');
+        // フォロー
+        Route::post('/follow/{id}', [UserController::class, 'follow'])->name('user.follow');
+        // フォロー解除
+        Route::post('/unfollow/{id}', [UserController::class, 'unfollow'])->name('user.unfollow');
+        // フォロー一覧
+        Route::get('/followed', [UserController::class, 'getAllFollowedUsers'])->name('user.followed');
+        // フォロワー一覧
+        Route::get('/follower', [UserController::class, 'getAllFollowerUsers'])->name('user.follower');
+    });
 
 
     // ツイート

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -47,9 +47,9 @@ Route::group(['middleware' => 'auth'], function () {
         // フォロー解除
         Route::post('/unfollow/{id}', [UserController::class, 'unfollow'])->name('user.unfollow');
         // フォロー一覧
-        Route::get('/followed', [UserController::class, 'getAllFollowedUsers'])->name('user.followed');
+        Route::get('/followed', [UserController::class, 'showFollowedUsers'])->name('user.followed');
         // フォロワー一覧
-        Route::get('/follower', [UserController::class, 'getAllFollowerUsers'])->name('user.follower');
+        Route::get('/follower', [UserController::class, 'showFollowerUsers'])->name('user.follower');
     });
 
 


### PR DESCRIPTION
# 課題のリンク
- フォロー・フォロワー一覧が見られる

# 改修内容
- マイページに「フォロー数」「フォロワー数」を表示
- それぞれフォロー一覧・フォロワー一覧に゙遷移

# キャプチャ
https://github.com/JoMashiko/twitter-clone/assets/143980390/4de77fb8-0316-4451-bf53-25513f858b71

# 検証内容
- followersテーブルの情報と表示内容が一致していることを目視で確認

# 相談事項
- なし

# 注意事項
- なし