### PR TITLE
投稿のキーワード検索ができる

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -56,15 +56,26 @@ class TweetController extends Controller
     }
 
     /**
-     * ツイート一覧を表示する
+     * ツイート一覧・検索結果を表示する
      * 
+     * @param Request $request
      * @return View
      */
-    public function getAllTweets(): View
+    public function getAllTweets(Request $request): View
     {
-        $tweets = $this->tweetModel->getAllTweets();
+        try {
+            $query = $request->input('query');
+            $tweets = $this->tweetModel->getAllTweets();
+            if ($query) {
+                $tweets = $this->tweetModel->searchByQuery($query);
+            }
 
-        return view('tweet.index', compact('tweets'));
+            return view('tweet.index', compact('tweets', 'query'));
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return redirect()->route('tweet.index')->with('message', 'エラーが発生しました');
+        }
     }
 
     /**
@@ -139,29 +150,6 @@ class TweetController extends Controller
             Log::error($e);
 
             return redirect()->route('tweet.index')->with('message', 'ツイートを削除に失敗しました');
-        }
-    }
-
-    /**
-     * ツイートを検索する
-     *
-     * @param Request $request
-     * @return View
-     */
-    public function searchByQuery(Request $request): View
-    {
-        try {
-            $query = $request->input('query');
-            $tweets = $this->tweetModel->getAllTweets();
-            if ($query) {
-                $tweets = $this->tweetModel->searchByQuery($query);
-            }
-
-            return view('tweet.index', compact('tweets', 'query'));
-        } catch (Exception $e) {
-            Log::error($e);
-
-            return redirect()->route('tweet.index')->with('message', 'エラーが発生しました');
         }
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -141,4 +141,27 @@ class TweetController extends Controller
             return redirect()->route('tweet.index')->with('message', 'ツイートを削除に失敗しました');
         }
     }
+
+    /**
+     * ツイートを検索する
+     *
+     * @param Request $request
+     * @return View
+     */
+    public function searchByQuery(Request $request): View
+    {
+        try {
+            $query = $request->input('query');
+            $tweets = $this->tweetModel->getAllTweets();
+            if ($query) {
+                $tweets = $this->tweetModel->searchByQuery($query);
+            }
+
+            return view('tweet.index', compact('tweets', 'query'));
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return redirect()->route('tweet.index')->with('message', 'エラーが発生しました');
+        }
+    }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -79,4 +79,15 @@ class Tweet extends Model
     {
         $this->delete();
     }
+
+    /**
+     * ツイートを検索する
+     *
+     * @param string $query
+     * @return Collection
+     */
+    public function searchByQuery(string $query): Collection
+    {
+        return Tweet::where('body', 'LIKE', '%' . $query . '%')->get();
+    }
 }

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -14,6 +14,16 @@
                     {{ session('message') }}
                 </div>
             @endif
+            <form method="GET" action="{{ route('tweet.search') }}">
+                <div class="input-group" style="margin-bottom: 20px">
+                    @if(isset($query))
+                        <input type="text"  name='query' class="form-control" value="{{ $query }}">
+                    @else
+                        <input type="text"  name='query' class="form-control" placeholder="キーワードを入力">
+                    @endif
+                    <button class="btn btn-outline-dark" type="submit" id="button-addon2" ><i class="fas fa-search"></i> 検索</button>
+                </div>
+            </form>
             @foreach($tweets as $tweet)
             <div class="card bg-white mb-3">
                 <a href="{{ route('tweet.show', $tweet->id) }}" class="card-body" style="text-decoration: none; color: inherit;">

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -14,7 +14,7 @@
                     {{ session('message') }}
                 </div>
             @endif
-            <form method="GET" action="{{ route('tweet.search') }}">
+            <form method="GET" action="{{ route('tweet.index') }}">
                 <div class="input-group" style="margin-bottom: 20px">
                     @if(isset($query))
                         <input type="text"  name='query' class="form-control" value="{{ $query }}">

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -72,3 +72,5 @@ Route::group(['middleware' => 'auth'], function () {
 
 // ツイート一覧
 Route::get('/tweets', [TweetController::class, 'getAllTweets'])->name('tweet.index');
+// 検索
+Route::get('/tweets/search', [TweetController::class, 'searchByQuery'])->name('tweet.search');

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -72,5 +72,3 @@ Route::group(['middleware' => 'auth'], function () {
 
 // ツイート一覧
 Route::get('/tweets', [TweetController::class, 'getAllTweets'])->name('tweet.index');
-// 検索
-Route::get('/tweets/search', [TweetController::class, 'searchByQuery'])->name('tweet.search');


### PR DESCRIPTION
# 課題のリンク
- 投稿のキーワード検索ができる

# 改修内容
- tweet.indexに検索フォームを追加
- キーワードでLIKE検索ができる
- nullの場合は全て取得して表示

# キャプチャ

https://github.com/JoMashiko/twitter-clone/assets/143980390/dabd4186-c866-45fa-9ccd-4b5e64d18489



# 検証内容
- tweetsテーブルと検索結果を目視で確認

# 相談事項
- なし

# 注意事項
- PRの内容に前回のフォロー・フォロワー一覧も含んでしまっています。申し訳ございません。
- こちら( https://github.com/JoMashiko/twitter-clone/pull/16/commits/37881b308fa1300206557cd6f33a7f7034c79169 )のレビューをお願いいたします。