### PR TITLE
リプライ機能

### DIFF
--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -23,6 +23,13 @@ class ReplyController extends Controller
         $this->reply = $reply;
     }
 
+    /**
+     * リプライを保存する
+     *
+     * @param CreateReplyRequest $request
+     * @param integer $tweetId
+     * @return RedirectResponse
+     */
     public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\CreateReplyRequest;
+use App\Http\Requests\Reply\CreateReplyRequest;
 use App\Models\Reply;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -23,14 +23,14 @@ class ReplyController extends Controller
         $this->reply = $reply;
     }
 
-    public function store(CreateReplyRequest $request): JsonResponse
+    public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {
             $reply = $request->validated();
             $userId = Auth::id();
-            $this->reply->store($reply, $userId);
+            $this->reply->store($tweetId, $userId, $reply);
 
-            return redirect()->json();
+            return redirect()->route('tweet.show', $tweetId)->with('reply', '保存しました');
         } catch (Exception $e) {
             Log::error($e);
 

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CreateReplyRequest;
+use App\Models\Reply;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class ReplyController extends Controller
+{
+    /**
+     * コンストラクタ
+     */
+    private $reply;
+
+    public function __construct(Reply $reply)
+    {
+        $this->reply = $reply;
+    }
+
+    public function store(CreateReplyRequest $request): JsonResponse
+    {
+        try {
+            $reply = $request->validated();
+            $userId = Auth::id();
+            $this->reply->store($reply, $userId);
+
+            return redirect()->json();
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return redirect()->route('tweet.index')->with('message', '投稿できませんでした');
+        }
+    }
+}

--- a/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
+++ b/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'body' => 'required|string|max:140'
+        ];
+    }
+}

--- a/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
+++ b/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Reply;
 
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -13,7 +13,7 @@ class CreateReplyRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/twitter/app/Http/Requests/Reply/UpdateRequest.php
+++ b/twitter/app/Http/Requests/Reply/UpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Reply;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -17,14 +17,16 @@ class Reply extends Model
     /**
      * リプライを保存する
      *
-     * @param array $reply
+     * @param int $tweetId
      * @param integer $userId
+     * @param array $reply
      * @return void
      */
-    public function store(array $reply, int $userId): void
+    public function store(int $tweetId, int $userId, array $reply): void
     {
-        $this->fill($reply);
+        $this->tweet_id = $tweetId;
         $this->user_id = $userId;
+        $this->fill($reply);
         $this->save();
     }
 

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Reply extends Model
+{
+    use HasFactory;
+
+    protected $table = 'replies';
+
+    protected $fillable = ['tweet_id', 'user_id', 'body'];
+
+    /**
+     * リプライを保存する
+     *
+     * @param array $reply
+     * @param integer $userId
+     * @return void
+     */
+    public function store(array $reply, int $userId): void
+    {
+        $this->fill($reply);
+        $this->user_id = $userId;
+        $this->save();
+    }
+
+    public function updateReply(): void
+    {
+    }
+
+    public function deleteReply(): void
+    {
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tweet()
+    {
+        return $this->belongsTo(Tweet::class);
+    }
+}

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -124,4 +124,14 @@ class Tweet extends Model
     {
         return Tweet::where('body', 'LIKE', '%' . $query . '%')->get();
     }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -133,4 +133,14 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'followers', 'followed_id', 'following_id');
     }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/twitter/database/migrations/2023_10_10_113332_create_replies_table.php
+++ b/twitter/database/migrations/2023_10_10_113332_create_replies_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tweet_id')->comment('ツイートID');
+            $table->unsignedBigInteger('user_id')->commnet('リプライしたユーザーID');
+            $table->string('body')->comment('リプライ本文');
+            $table->timestamps();
+
+            $table->foreign('tweet_id')
+                ->references('id')->on('tweets')->onDelete('cascade');
+            $table->foreign('user_id')
+                ->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+};

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -36,20 +36,37 @@
                         {{ $tweet->body }}
                     </p>
                 </a>
-                <div style="margin-left: 20px">
-                    @if($tweet->isFavorite($tweet->id, auth()->id()))
-                        {{-- いいね済 --}}
-                        <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-solid fa-heart" style="color: #f91880;"></i>
-                            <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                    @else
-                        {{-- いいね未 --}}
-                        <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-regular fa-heart" style="color: #202124;"></i>
-                            <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                    @endif
+                <div style="display: flex; align-items: center;">
+                    {{-- リプライボタン --}}
+                    <div style="margin-left: 12px">
+                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-comment"></i>
+                            </button>
+                        @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-comment"></i>
+                            </button>
+                        @endif
+                    </div>
+                    {{-- いいねボタン  --}}
+                    <div style="margin-left: 20px">
+                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-solid fa-heart" style="color: #f91880;"></i>
+                                <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                        @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-heart" style="color: #202124;"></i>
+                                <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                        @endif
+                    </div>
                 </div>
             </div>
             @endforeach

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -37,37 +37,52 @@
                     </p>
                 </a>
                 <div style="display: flex; align-items: center;">
-                    {{-- リプライボタン --}}
-                    <div style="margin-left: 12px">
-                        @if($tweet->isFavorite($tweet->id, auth()->id()))
-                            {{-- いいね済 --}}
-                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                                <i class="fa-regular fa-comment"></i>
-                            </button>
-                        @else
-                            {{-- いいね未 --}}
-                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                                <i class="fa-regular fa-comment"></i>
-                            </button>
-                        @endif
-                    </div>
-                    {{-- いいねボタン  --}}
-                    <div style="margin-left: 20px">
-                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                    {{-- リプライボタン(tiriger modal) --}}
+                        <button type="button" class="reply-button btn btn-primary" data-bs-toggle="modal" data-bs-target="#{{ $tweet->id }}" style="background: transparent; border: none; margin-left: 8px">
+                            <i class="fa-regular fa-comment" style="color: #202124;"></i>
+                        </button>
+
+                        {{-- いいねボタン  --}}
+                        <div style="margin-left: 20px">
+                            @if($tweet->isFavorite($tweet->id, auth()->id()))
                             {{-- いいね済 --}}
                             <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-solid fa-heart" style="color: #f91880;"></i>
                                 <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                        @else
+                            @else
                             {{-- いいね未 --}}
                             <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-regular fa-heart" style="color: #202124;"></i>
                                 <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                        @endif
+                            @endif
+                        </div>
                     </div>
                 </div>
+                {{-- Modal --}}
+                <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
+                    @csrf
+                    <div class="modal fade" id="{{ $tweet->id}}" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                            <div class="modal-body">
+                                <div class="mb-3">
+                                    <label for="message-text" class="col-form-label">リプライ</label>
+                                    <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
+                                    @error('body')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                    @enderror
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button class="btn btn-outline-primary" type="submit">{{ __('返信') }}</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </div>
             @endforeach
         </div>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -14,6 +14,11 @@
                     {{ session('message') }}
                 </div>
             @endif
+            @if(session('reply'))
+                <div class="alert alert-success">
+                    {{ session('reply') }}
+                </div>
+            @endif
             <div class="card bg-white mb-3">
                 <div class="card-body">
                     <h6 class="card-title">
@@ -24,25 +29,34 @@
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
-                    @if($tweet->isFavorite($tweet->id, auth()->id()))
-                        {{-- いいね済 --}}
-                        <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-solid fa-heart" style="color: #f91880;"></i>
-                            <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                    <div style="display: flex; align-items: center;">
+                        {{-- リプライボタン(tiriger modal) --}}
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" style="background: transparent; border: none;">
+                            <i class="fa-regular fa-comment" style="color: #202124;"></i>
                         </button>
-                    @else
-                        {{-- いいね未 --}}
-                        <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-regular fa-heart" style="color: #202124;"></i>
-                            <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                        @endif
-                    @can('update', $tweet)
-                        <div class="d-grid d-md-flex justify-content-md-end">
-                            <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
-                                {{ __('編集') }}
+                        {{-- いいねボタン  --}}
+                        <div style="margin-left: 20px">
+                            @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-solid fa-heart" style="color: #f91880;"></i>
+                                <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                            <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
+                            @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-heart" style="color: #202124;"></i>
+                                <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                            @endif
+                        </div>
+                    </div>
+                    @can('update', $tweet)
+                    <div class="d-grid d-md-flex justify-content-md-end">
+                        <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
+                            {{ __('編集') }}
+                        </button>
+                        <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
                             return confirm('本当にツイートを削除してもよろしいですか？');">
                                 @csrf
                                 @method('delete')
@@ -54,6 +68,29 @@
                     @endcan
                 </div>
             </div>
+            {{-- Modal --}}
+            <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
+                @csrf
+                <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                        <div class="modal-body">
+                            <div class="mb-3">
+                                <label for="message-text" class="col-form-label">リプライ</label>
+                                <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
+                                @error('body')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button class="reply-button btn btn-outline-primary">{{ __('返信') }}</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FavoriteController;
 use App\Models\Favorite;
+use App\Models\Reply;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\Routing\Route as RoutingRoute;
 
@@ -73,6 +74,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/favorite', [FavoriteController::class, 'favorite'])->name('tweet.favorite');
         // いいね解除
         Route::post('/unfavorite', [FavoriteController::class, 'unfavorite'])->name('tweet.unfavorite');
+        // リプライ保存
+        Route::post('/{id}/store', [ReplyController::class, 'store'])->name('reply.store');
     });
 
     // ツイート一覧

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -3,8 +3,7 @@
 use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FavoriteController;
-use App\Models\Favorite;
-use App\Models\Reply;
+use App\Http\Controllers\ReplyController;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\Routing\Route as RoutingRoute;
 


### PR DESCRIPTION
# 課題のリンク
- ツイートにリプライができる

# 改修内容
- repliesテーブルを追加
- ツイート詳細にリプライボタンを追加
- リプライボタンを押すとリプライ投稿のモーダルが開く
- 送信をクリックするとrepliesテーブルにtweet_id, user_id, bodyが保存される

# キャプチャ

https://github.com/JoMashiko/twitter-clone/assets/143980390/df3e8960-ea09-4f0e-9518-d7110693e0a4

# 検証内容
- 送信ボタンをクリック後、repliesテーブルに保存されていることを目視で確認