### PR TITLE
リプライ一覧・編集・削除機能

### DIFF
--- a/twitter/app/Http/Controllers/FavoriteController.php
+++ b/twitter/app/Http/Controllers/FavoriteController.php
@@ -37,7 +37,7 @@ class FavoriteController extends Controller
         $this->favoriteModel->favorite($tweetId, $userId);
 
         // いいねの数を取得
-        $tweet = $this->tweetModel->findByTweetId($tweetId);
+        $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
         $favoriteCount = $tweet->favoriteCount();
 
         return response()->json(['favoriteCount' => $favoriteCount]);
@@ -60,7 +60,7 @@ class FavoriteController extends Controller
         }
 
         // いいねの数を取得
-        $tweet = $this->tweetModel->findByTweetId($tweetId);
+        $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
         $favoriteCount = $tweet->favoriteCount();
 
         return response()->json(['favoriteCount' => $favoriteCount]);

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -23,6 +23,13 @@ class ReplyController extends Controller
         $this->reply = $reply;
     }
 
+    /**
+     * リプライを保存する
+     *
+     * @param CreateReplyRequest $request
+     * @param integer $tweetId
+     * @return RedirectResponse
+     */
     public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\CreateReplyRequest;
+use App\Http\Requests\Reply\CreateReplyRequest;
 use App\Models\Reply;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -23,14 +23,14 @@ class ReplyController extends Controller
         $this->reply = $reply;
     }
 
-    public function store(CreateReplyRequest $request): JsonResponse
+    public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {
             $reply = $request->validated();
             $userId = Auth::id();
-            $this->reply->store($reply, $userId);
+            $this->reply->store($tweetId, $userId, $reply);
 
-            return redirect()->json();
+            return redirect()->route('tweet.show', $tweetId)->with('reply', '保存しました');
         } catch (Exception $e) {
             Log::error($e);
 

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CreateReplyRequest;
+use App\Models\Reply;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class ReplyController extends Controller
+{
+    /**
+     * コンストラクタ
+     */
+    private $reply;
+
+    public function __construct(Reply $reply)
+    {
+        $this->reply = $reply;
+    }
+
+    public function store(CreateReplyRequest $request): JsonResponse
+    {
+        try {
+            $reply = $request->validated();
+            $userId = Auth::id();
+            $this->reply->store($reply, $userId);
+
+            return redirect()->json();
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return redirect()->route('tweet.index')->with('message', '投稿できませんでした');
+        }
+    }
+}

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -34,8 +34,10 @@ class ReplyController extends Controller
     public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {
-            $userId = Auth::id();
-            $this->reply->store($tweetId, $userId, $request->validated());
+            $replyParam = $request->validated();
+            $replyParam['user_id'] = Auth::id();
+            $replyParam['tweet_id'] = $tweetId;
+            $this->reply->store($replyParam);
 
             return redirect()->route('tweet.show', $tweetId)->with('reply', '保存しました');
         } catch (Exception $e) {

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -79,6 +79,7 @@ class ReplyController extends Controller
     {
         try {
             $reply = $this->reply->findByReplyId($replyId);
+            $this->authorize('delete', $reply);
             $reply->deleteReply();
 
             return back()->with('success', 'リプライを削除しました');

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -34,9 +34,8 @@ class ReplyController extends Controller
     public function store(CreateReplyRequest $request, int $tweetId): RedirectResponse
     {
         try {
-            $reply = $request->validated();
             $userId = Auth::id();
-            $this->reply->store($tweetId, $userId, $reply);
+            $this->reply->store($tweetId, $userId, $request->validated());
 
             return redirect()->route('tweet.show', $tweetId)->with('reply', '保存しました');
         } catch (Exception $e) {
@@ -59,7 +58,7 @@ class ReplyController extends Controller
             $replyParam = $request->validated();
             $reply = $this->reply->findByReplyId($replyId);
             $this->authorize('update', $reply);
-            $reply->updateReply($replyParam, $reply);
+            $reply->updateReply($replyParam);
 
             return back()->with('success', 'リプライを更新しました');
         } catch (Exception $e) {

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Reply\CreateReplyRequest;
+use App\Http\Requests\Reply\UpdateRequest;
 use App\Models\Reply;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -42,6 +43,49 @@ class ReplyController extends Controller
             Log::error($e);
 
             return redirect()->route('tweet.index')->with('message', '投稿できませんでした');
+        }
+    }
+
+    /**
+     * リプライを更新する
+     *
+     * @param UpdateRequest $request
+     * @param integer $replyId
+     * @return RedirectResponse
+     */
+    public function update(UpdateRequest $request, int $replyId): RedirectResponse
+    {
+        try {
+            $replyParam = $request->validated();
+            $reply = $this->reply->findByReplyId($replyId);
+            $this->authorize('update', $reply);
+            $reply->updateReply($replyParam, $reply);
+
+            return back()->with('success', 'リプライを更新しました');
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return back()->with('message', 'リプライの更新に失敗しました');
+        }
+    }
+
+    /**
+     * リプライを削除する
+     * 
+     * @param int $tweetId ユーザーID
+     * @return RedirectResponse
+     */
+    public function delete(int $replyId): RedirectResponse
+    {
+        try {
+            $reply = $this->reply->findByReplyId($replyId);
+            $reply->deleteReply();
+
+            return back()->with('success', 'リプライを削除しました');
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return back()->with('message', 'リプライの削除に失敗しました');
         }
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -143,8 +143,8 @@ class TweetController extends Controller
     public function delete(int $tweetId): RedirectResponse
     {
         try {
-            $user = $this->tweetModel->findByTweetId($tweetId);
-            $user->deleteTweet();
+            $tweet = $this->tweetModel->findByTweetId($tweetId);
+            $tweet->deleteTweet();
 
             return redirect()->route('tweet.index')->with('success', 'ツイートを削除しました');
         } catch (Exception $e) {

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -79,7 +79,7 @@ class TweetController extends Controller
     }
 
     /**
-     * ツイートIDに基づいてツイートを検索し、詳細画面を表示する
+     * ツイートIDに基づいてツイートとリプライを検索し、詳細画面を表示する
      * 
      * @param int $tweetId
      * @return View
@@ -88,8 +88,9 @@ class TweetController extends Controller
     {
         try {
             $tweet = $this->tweetModel->findByTweetId($tweetId);
+            $replies = $tweet->getReplies();
 
-            return view('tweet.show', compact('tweet'));
+            return view('tweet.show', compact('tweet', 'replies'));
         } catch (Exception $e) {
             Log::error($e);
 

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -86,15 +86,12 @@ class TweetController extends Controller
      */
     public function findByTweetId(int $tweetId)
     {
-        try {
-            $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
-
-            return view('tweet.show', compact('tweet'));
-        } catch (Exception $e) {
-            Log::error($e);
-
-            return redirect()->route('tweet.index')->with('message', 'ツイートが見つかりませんでした');
+        $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
+        if (!$tweet) {
+            abort(404);
         }
+
+        return view('tweet.show', compact('tweet'));
     }
 
     /**
@@ -143,6 +140,7 @@ class TweetController extends Controller
     {
         try {
             $tweet = $this->tweetModel->findByTweetId($tweetId);
+            $this->authorize('delete', $tweet);
             $tweet->deleteTweet();
 
             return redirect()->route('tweet.index')->with('success', 'ツイートを削除しました');

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -102,7 +102,7 @@ class TweetController extends Controller
      */
     public function edit(int $tweetId): View
     {
-        $tweet = $this->tweetModel->findByTweetId($tweetId);
+        $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
 
         return view('tweet.edit', compact('tweet'));
     }
@@ -118,7 +118,7 @@ class TweetController extends Controller
     {
         try {
             $tweetParam = $request->validated();
-            $tweet = $this->tweetModel->findByTweetId($tweetId);
+            $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
             $this->authorize('update', $tweet);
             $tweet->updateTweet($tweetParam, $tweet);
 
@@ -139,7 +139,7 @@ class TweetController extends Controller
     public function delete(int $tweetId): RedirectResponse
     {
         try {
-            $tweet = $this->tweetModel->findByTweetId($tweetId);
+            $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
             $this->authorize('delete', $tweet);
             $tweet->deleteTweet();
 

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -87,10 +87,9 @@ class TweetController extends Controller
     public function findByTweetId(int $tweetId)
     {
         try {
-            $tweet = $this->tweetModel->findByTweetId($tweetId);
-            $replies = $tweet->getReplies();
+            $tweet = $this->tweetModel->findTweetAndRepliesByTweetId($tweetId);
 
-            return view('tweet.show', compact('tweet', 'replies'));
+            return view('tweet.show', compact('tweet'));
         } catch (Exception $e) {
             Log::error($e);
 

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -5,9 +5,11 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use App\Http\Requests\User\UpdateRequest;
 use App\Models\Follower;
+use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
 
 class UserController extends Controller
 {
@@ -29,13 +31,19 @@ class UserController extends Controller
      * @param int $userId ユーザーID
      * @return View
      */
-    public function showUserInfo(int $userId): View
+    public function showUserInfo(int $userId)
     {
-        $user = $this->userModel->findByUserId($userId);
-        $followedCount = $this->followerModel->countFollowedUsers($user);
-        $followerCount = $this->followerModel->countFollowerUsers($user);
+        try {
+            $user = $this->userModel->findByUserId($userId);
+            $followedCount = $this->followerModel->countFollowedUsers($user);
+            $followerCount = $this->followerModel->countFollowerUsers($user);
 
-        return view('user.show', compact('user', 'followedCount', 'followerCount'));
+            return view('user.show', compact('user', 'followedCount', 'followerCount'));
+        } catch (Exception $e) {
+            Log::error($e);
+
+            return redirect()->route('tweet.index')->with('message', 'エラーが発生しました');
+        }
     }
 
     /**

--- a/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
+++ b/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'body' => 'required|string|max:140'
+        ];
+    }
+}

--- a/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
+++ b/twitter/app/Http/Requests/Reply/CreateReplyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Reply;
 
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -13,7 +13,7 @@ class CreateReplyRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/twitter/app/Http/Requests/Reply/UpdateRequest.php
+++ b/twitter/app/Http/Requests/Reply/UpdateRequest.php
@@ -13,7 +13,7 @@ class UpdateRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -24,7 +24,7 @@ class UpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'body' => 'required|string|max:140'
         ];
     }
 }

--- a/twitter/app/Http/Requests/Reply/UpdateRequest.php
+++ b/twitter/app/Http/Requests/Reply/UpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Reply;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -17,14 +17,16 @@ class Reply extends Model
     /**
      * リプライを保存する
      *
-     * @param array $reply
+     * @param int $tweetId
      * @param integer $userId
+     * @param array $reply
      * @return void
      */
-    public function store(array $reply, int $userId): void
+    public function store(int $tweetId, int $userId, array $reply): void
     {
-        $this->fill($reply);
+        $this->tweet_id = $tweetId;
         $this->user_id = $userId;
+        $this->fill($reply);
         $this->save();
     }
 

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -30,21 +30,57 @@ class Reply extends Model
         $this->save();
     }
 
-    public function updateReply(): void
+    /**
+     * リプライを更新する
+     *
+     * @param array $replyParam
+     * @param Reply $reply
+     * @return void
+     */
+    public function updateReply(array $replyParam, Reply $reply): void
     {
+        $reply->fill($replyParam);
+        $reply->update();
     }
 
+    /**
+     * リプライを削除する
+     *
+     * @return void
+     */
     public function deleteReply(): void
     {
+        $this->delete();
     }
 
+    /**
+     * リレーション
+     *
+     * @return void
+     */
     public function user()
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * リレーション
+     *
+     * @return void
+     */
     public function tweet()
     {
         return $this->belongsTo(Tweet::class);
+    }
+
+    /**
+     * リプライIDに基づいてリプライを検索し、一致するリプライを返す
+     * 
+     * @param int $replyId
+     * @return Reply
+     */
+    public function findByReplyId(int $replyId): Reply
+    {
+        return Reply::findOrFail($replyId);
     }
 }

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Reply extends Model
+{
+    use HasFactory;
+
+    protected $table = 'replies';
+
+    protected $fillable = ['tweet_id', 'user_id', 'body'];
+
+    /**
+     * リプライを保存する
+     *
+     * @param array $reply
+     * @param integer $userId
+     * @return void
+     */
+    public function store(array $reply, int $userId): void
+    {
+        $this->fill($reply);
+        $this->user_id = $userId;
+        $this->save();
+    }
+
+    public function updateReply(): void
+    {
+    }
+
+    public function deleteReply(): void
+    {
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tweet()
+    {
+        return $this->belongsTo(Tweet::class);
+    }
+}

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -22,11 +22,11 @@ class Reply extends Model
      * @param array $reply
      * @return void
      */
-    public function store(int $tweetId, int $userId, array $reply): void
+    public function store(int $tweetId, int $userId, array $replyParam): void
     {
         $this->tweet_id = $tweetId;
         $this->user_id = $userId;
-        $this->fill($reply);
+        $this->fill($replyParam);
         $this->save();
     }
 
@@ -37,10 +37,10 @@ class Reply extends Model
      * @param Reply $reply
      * @return void
      */
-    public function updateReply(array $replyParam, Reply $reply): void
+    public function updateReply(array $replyParam): void
     {
-        $reply->fill($replyParam);
-        $reply->update();
+        $this->fill($replyParam);
+        $this->update();
     }
 
     /**

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -22,10 +22,8 @@ class Reply extends Model
      * @param array $reply
      * @return void
      */
-    public function store(int $tweetId, int $userId, array $replyParam): void
+    public function store(array $replyParam): void
     {
-        $this->tweet_id = $tweetId;
-        $this->user_id = $userId;
         $this->fill($replyParam);
         $this->save();
     }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -50,14 +50,14 @@ class Tweet extends Model
     }
 
     /**
-     * ツイートIDに基づいてツイートを検索し、一致するツイートを返す
+     * ツイートIDに基づいてツイートとリプライを検索し、一致するツイートを返す
      * 
      * @param int $tweetId
      * @return Tweet $tweet
      */
-    public function findByTweetId(int $tweetId): Tweet
+    public function findTweetAndRepliesByTweetId(int $tweetId): Tweet
     {
-        return Tweet::findOrFail($tweetId);
+        return Tweet::with('replies')->findOrFail($tweetId);
     }
 
     /**
@@ -133,15 +133,5 @@ class Tweet extends Model
     public function replies(): Hasmany
     {
         return $this->hasMany(Reply::class);
-    }
-
-    /**
-     * リプライを取得する
-     *
-     * @return Collection
-     */
-    public function getReplies(): Collection
-    {
-        return $this->replies;
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -124,4 +124,14 @@ class Tweet extends Model
     {
         return Tweet::where('body', 'LIKE', '%' . $query . '%')->get();
     }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -128,10 +128,20 @@ class Tweet extends Model
     /**
      * リレーション
      *
-     * @return void
+     * @return Hasmany
      */
-    public function replies()
+    public function replies(): Hasmany
     {
         return $this->hasMany(Reply::class);
+    }
+
+    /**
+     * リプライを取得する
+     *
+     * @return Collection
+     */
+    public function getReplies(): Collection
+    {
+        return $this->replies;
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -73,7 +73,7 @@ class Tweet extends Model
     }
 
     /**
-     * ユーザーを削除する
+     * ツイートを削除する
      */
     public function deleteTweet(): void
     {

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -133,4 +133,14 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'followers', 'followed_id', 'following_id');
     }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/twitter/app/Policies/ReplyPolicy.php
+++ b/twitter/app/Policies/ReplyPolicy.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Reply;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ReplyPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Reply  $reply
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Reply $reply)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Reply  $reply
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Reply $reply)
+    {
+        return $user->id === $reply->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Reply  $reply
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Reply $reply)
+    {
+        return $user->id === $reply->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Reply  $reply
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function restore(User $user, Reply $reply)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Reply  $reply
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function forceDelete(User $user, Reply $reply)
+    {
+        //
+    }
+}

--- a/twitter/composer.json
+++ b/twitter/composer.json
@@ -14,6 +14,7 @@
         "laravel/ui": "^4.2"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.9",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.4",

--- a/twitter/composer.lock
+++ b/twitter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b3af047515101aed2d267f086d90f1d",
+    "content-hash": "9aee13a617b9306f82962cc0204bf5dd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5705,6 +5705,90 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "bfd0131c146973cab164e50f5cdd8a67cc60cab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/bfd0131c146973cab164e50f5cdd8a67cc60cab1",
+                "reference": "bfd0131c146973cab164e50f5cdd8a67cc60cab1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^9|^10",
+                "illuminate/session": "^9|^10",
+                "illuminate/support": "^9|^10",
+                "maximebf/debugbar": "^1.18.2",
+                "php": "^8.0",
+                "symfony/finder": "^6"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^5|^6|^7|^8",
+                "phpunit/phpunit": "^8.5.30|^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.8-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facades\\Debugbar"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-debugbar/issues",
+                "source": "https://github.com/barryvdh/laravel-debugbar/tree/v3.9.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-25T18:43:57+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "2.0.0",
             "source": {
@@ -6028,6 +6112,72 @@
                 "source": "https://github.com/laravel/sail"
             },
             "time": "2023-06-16T21:20:12+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "30f65f18f7ac086255a77a079f8e0dcdd35e828e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/30f65f18f7ac086255a77a079f8e0dcdd35e828e",
+                "reference": "30f65f18f7ac086255a77a079f8e0dcdd35e828e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^4|^5|^6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=7.5.20 <10.0",
+                "twig/twig": "^1.38|^2.7|^3.0"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "support": {
+                "issues": "https://github.com/maximebf/php-debugbar/issues",
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.19.0"
+            },
+            "time": "2023-09-19T19:53:10+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -8186,5 +8336,5 @@
         "php": "^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/twitter/config/const.php
+++ b/twitter/config/const.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'fav_val' => [
+        'favorited' => 1,
+        'unfavorite' => 0,
+    ],
+];

--- a/twitter/database/migrations/2023_10_10_113332_create_replies_table.php
+++ b/twitter/database/migrations/2023_10_10_113332_create_replies_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tweet_id')->comment('ツイートID');
+            $table->unsignedBigInteger('user_id')->commnet('リプライしたユーザーID');
+            $table->string('body')->comment('リプライ本文');
+            $table->timestamps();
+
+            $table->foreign('tweet_id')
+                ->references('id')->on('tweets')->onDelete('cascade');
+            $table->foreign('user_id')
+                ->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+};

--- a/twitter/public/js/favorite-button.js
+++ b/twitter/public/js/favorite-button.js
@@ -11,62 +11,84 @@ $.ajaxSetup({
 $(document).ready(function () {
   $('.favorite-button').on('click', function () {
     var tweetId = $(this).data('tweet-id'); // クリックされたボタンのtweet-idを取得
-    var fav_val = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
+    var favoriteVal = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
     var clickedButton = $(this); // クリックされたボタンを変数に格納
     var favoriteCountSpan = clickedButton.parent().find('.favoriteCount'); // 親要素内からfavoriteCount要素を取得
 
-    if (fav_val == '1') {
-      // いいね済の場合
-      $.ajax({
-        url: "/tweet/unfavorite",
-        method: "POST",
-        data: {
-          tweetId: tweetId
-        },
-        dataType: "json"
-      }).done(function (data) {
-        // 成功時の処理
-        clickedButton.attr('fav_val', '0'); //fav_val属性を更新
-
-        // アイコンのクラスと色を変更
-        clickedButton.find('i.fa-solid').removeClass('fa-solid').addClass('fa-regular');
-        clickedButton.find('i').css('color', '#202124');
-
-        // favoriteCountの数と色を変更
-        favoriteCountSpan.html(data.favoriteCount);
-        favoriteCountSpan.css('color', '#202124');
-      }).fail(function (error) {
-        console.log(error.statusText);
-        // エラーメッセージ
-        alert("通信エラーが発生しました。");
-      });
+    if (favoriteVal == '1') {
+      unfavoriteTweet(tweetId, clickedButton, favoriteCountSpan);
     } else {
-      // いいね未の場合
-      $.ajax({
-        url: "/tweet/favorite",
-        method: "POST",
-        data: {
-          tweetId: tweetId
-        },
-        dataType: "json"
-      }).done(function (data) {
-        // 成功時の処理
-        clickedButton.attr('fav_val', '1'); //fav_val属性を更新
-
-        // アイコンのクラスと色を変更
-        clickedButton.find('i.fa-regular').removeClass('fa-regular').addClass('fa-solid');
-        clickedButton.find('i').css('color', '#f91880');
-
-        // favoriteCountの数と色を変更
-        favoriteCountSpan.html(data.favoriteCount);
-        favoriteCountSpan.css('color', '#f91880');
-      }).fail(function (error) {
-        console.log(error.statusText);
-        // エラーメッセージ
-        alert("通信エラーが発生しました。");
-      });
+      favoriteTweet(tweetId, clickedButton, favoriteCountSpan);
     }
   });
 });
+
+/**
+ * いいね解除のAjaxリクエストを送る
+ *
+ * @param {*} tweetId
+ * @param {*} clickedButton
+ * @param {*} favoriteCountSpan
+ */
+function unfavoriteTweet(tweetId, clickedButton, favoriteCountSpan) {
+  $.ajax({
+    url: "/tweet/unfavorite",
+    method: "POST",
+    data: {
+      tweetId: tweetId
+    },
+    dataType: "json"
+  }).done(function (data) {
+    //fav_val属性を更新
+    clickedButton.attr('fav_val', '0');
+
+    // アイコンのクラスと色を変更
+    clickedButton.find('i.fa-solid').removeClass('fa-solid').addClass('fa-regular');
+    clickedButton.find('i').css('color', '#202124');
+
+    // favoriteCountの数と色を変更
+    favoriteCountSpan.html(data.favoriteCount);
+    favoriteCountSpan.css('color', '#202124');
+  }).fail(handleAjaxError);
+}
+
+/**
+ * いいねのAjaxリクエストを送る
+ *
+ * @param {*} tweetId
+ * @param {*} clickedButton
+ * @param {*} favoriteCountSpan
+ */
+function favoriteTweet(tweetId, clickedButton, favoriteCountSpan) {
+  $.ajax({
+    url: "/tweet/favorite",
+    method: "POST",
+    data: {
+      tweetId: tweetId
+    },
+    dataType: "json"
+  }).done(function (data) {
+    //fav_val属性を更新
+    clickedButton.attr('fav_val', '1');
+
+    // アイコンのクラスと色を変更
+    clickedButton.find('i.fa-regular').removeClass('fa-regular').addClass('fa-solid');
+    clickedButton.find('i').css('color', '#f91880');
+
+    // favoriteCountの数と色を変更
+    favoriteCountSpan.html(data.favoriteCount);
+    favoriteCountSpan.css('color', '#f91880');
+  }).fail(handleAjaxError);
+}
+
+/**
+ * エラー対応
+ *
+ * @param {*} error
+ */
+function handleAjaxError(error) {
+  console.log(error.statusText);
+  alert("通信エラーが発生しました。");
+}
 /******/ })()
 ;

--- a/twitter/public/js/favorite-button.js
+++ b/twitter/public/js/favorite-button.js
@@ -10,10 +10,10 @@ $.ajaxSetup({
 });
 $(document).ready(function () {
   $('.favorite-button').on('click', function () {
-    var tweetId = $(this).data('tweet-id'); // クリックされたボタンのtweet-idを取得
-    var favoriteVal = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
-    var clickedButton = $(this); // クリックされたボタンを変数に格納
-    var favoriteCountSpan = clickedButton.parent().find('.favoriteCount'); // 親要素内からfavoriteCount要素を取得
+    const tweetId = $(this).data('tweet-id'); // クリックされたボタンのtweet-idを取得
+    const favoriteVal = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
+    const clickedButton = $(this); // クリックされたボタンを変数に格納
+    const favoriteCountSpan = clickedButton.parent().find('.favoriteCount'); // 親要素内からfavoriteCount要素を取得
 
     if (favoriteVal == '1') {
       unfavoriteTweet(tweetId, clickedButton, favoriteCountSpan);

--- a/twitter/resources/js/favorite-button.js
+++ b/twitter/resources/js/favorite-button.js
@@ -4,56 +4,80 @@ $.ajaxSetup({
 $(document).ready(function(){
     $('.favorite-button').on('click', function(){
         const tweetId = $(this).data('tweet-id'); // クリックされたボタンのtweet-idを取得
-        const fav_val = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
+        const favoriteVal = $(this).attr("fav_val"); // クリックされたボタンのfav_val属性を取得
         const clickedButton = $(this); // クリックされたボタンを変数に格納
         const favoriteCountSpan = clickedButton.parent().find('.favoriteCount'); // 親要素内からfavoriteCount要素を取得
 
-        if(fav_val=='1'){
-            // いいね済の場合
-            $.ajax({
-                url: "/tweet/unfavorite",
-                method: "POST",
-                data: { tweetId : tweetId },
-                dataType: "json",
-            }).done(function(data){
-                // 成功時の処理
-                clickedButton.attr('fav_val','0'); //fav_val属性を更新
-
-                // アイコンのクラスと色を変更
-                clickedButton.find('i.fa-solid').removeClass('fa-solid').addClass('fa-regular');
-                clickedButton.find('i').css('color', '#202124');
-                
-                // favoriteCountの数と色を変更
-                favoriteCountSpan.html(data.favoriteCount);
-                favoriteCountSpan.css('color', '#202124');
-            }).fail((error) => {
-                console.log(error.statusText);
-                // エラーメッセージ
-                alert("通信エラーが発生しました。");
-            });
+        if(favoriteVal=='1'){
+            unfavoriteTweet(tweetId, clickedButton, favoriteCountSpan);
         } else {
-            // いいね未の場合
-            $.ajax({
-                url: "/tweet/favorite",
-                method: "POST",
-                data: { tweetId : tweetId },
-                dataType: "json",
-            }).done(function(data){
-                // 成功時の処理
-                clickedButton.attr('fav_val','1') //fav_val属性を更新
-
-                // アイコンのクラスと色を変更
-                clickedButton.find('i.fa-regular').removeClass('fa-regular').addClass('fa-solid');
-                clickedButton.find('i').css('color', '#f91880');
-
-                // favoriteCountの数と色を変更
-                favoriteCountSpan.html(data.favoriteCount);
-                favoriteCountSpan.css('color', '#f91880');
-            }).fail((error) => {
-                console.log(error.statusText);
-                // エラーメッセージ
-                alert("通信エラーが発生しました。");
-            });
+            favoriteTweet(tweetId, clickedButton, favoriteCountSpan);
         }
     });
 });
+
+
+/**
+ * いいね解除のAjaxリクエストを送る
+ *
+ * @param {*} tweetId
+ * @param {*} clickedButton
+ * @param {*} favoriteCountSpan
+ */
+function unfavoriteTweet(tweetId, clickedButton, favoriteCountSpan){
+    $.ajax({
+        url: "/tweet/unfavorite",
+        method: "POST",
+        data: { tweetId : tweetId },
+        dataType: "json",
+    }).done(function(data){
+        //fav_val属性を更新
+        clickedButton.attr('fav_val','0');
+
+        // アイコンのクラスと色を変更
+        clickedButton.find('i.fa-solid').removeClass('fa-solid').addClass('fa-regular');
+        clickedButton.find('i').css('color', '#202124');
+        
+        // favoriteCountの数と色を変更
+        favoriteCountSpan.html(data.favoriteCount);
+        favoriteCountSpan.css('color', '#202124');
+    }).fail(handleAjaxError);
+}
+
+
+/**
+ * いいねのAjaxリクエストを送る
+ *
+ * @param {*} tweetId
+ * @param {*} clickedButton
+ * @param {*} favoriteCountSpan
+ */
+function favoriteTweet(tweetId, clickedButton, favoriteCountSpan){
+    $.ajax({
+        url: "/tweet/favorite",
+        method: "POST",
+        data: { tweetId : tweetId },
+        dataType: "json",
+    }).done(function(data){
+        //fav_val属性を更新
+        clickedButton.attr('fav_val','1') 
+
+        // アイコンのクラスと色を変更
+        clickedButton.find('i.fa-regular').removeClass('fa-regular').addClass('fa-solid');
+        clickedButton.find('i').css('color', '#f91880');
+
+        // favoriteCountの数と色を変更
+        favoriteCountSpan.html(data.favoriteCount);
+        favoriteCountSpan.css('color', '#f91880');
+    }).fail(handleAjaxError);
+}
+
+/**
+ * エラー対応
+ *
+ * @param {*} error
+ */
+function handleAjaxError(error) {
+    console.log(error.statusText);
+    alert("通信エラーが発生しました。");
+}

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -37,7 +37,7 @@
                     </p>
                 </a>
                 <div style="display: flex; align-items: center;">
-                    {{-- リプライボタン(tiriger modal) --}}
+                    {{-- リプライボタン --}}
                         <button type="button" class="reply-button btn btn-primary" data-bs-toggle="modal" data-bs-target="#{{ $tweet->id }}" style="background: transparent; border: none; margin-left: 8px">
                             <i class="fa-regular fa-comment" style="color: #202124;"></i>
                             <span class="replyCount" style="color: #202124; margin-left: 5px;">{{ $tweet->replies->count() }}</span>
@@ -61,7 +61,7 @@
                         </div>
                     </div>
                 </div>
-                {{-- Modal --}}
+                {{-- リプライのモーダル --}}
                 <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
                     @csrf
                     <div class="modal fade" id="{{ $tweet->id}}" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -36,20 +36,37 @@
                         {{ $tweet->body }}
                     </p>
                 </a>
-                <div style="margin-left: 20px">
-                    @if($tweet->isFavorite($tweet->id, auth()->id()))
-                        {{-- いいね済 --}}
-                        <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-solid fa-heart" style="color: #f91880;"></i>
-                            <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                    @else
-                        {{-- いいね未 --}}
-                        <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-regular fa-heart" style="color: #202124;"></i>
-                            <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                    @endif
+                <div style="display: flex; align-items: center;">
+                    {{-- リプライボタン --}}
+                    <div style="margin-left: 12px">
+                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-comment"></i>
+                            </button>
+                        @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-comment"></i>
+                            </button>
+                        @endif
+                    </div>
+                    {{-- いいねボタン  --}}
+                    <div style="margin-left: 20px">
+                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-solid fa-heart" style="color: #f91880;"></i>
+                                <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                        @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-heart" style="color: #202124;"></i>
+                                <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                        @endif
+                    </div>
                 </div>
             </div>
             @endforeach

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -40,6 +40,7 @@
                     {{-- リプライボタン(tiriger modal) --}}
                         <button type="button" class="reply-button btn btn-primary" data-bs-toggle="modal" data-bs-target="#{{ $tweet->id }}" style="background: transparent; border: none; margin-left: 8px">
                             <i class="fa-regular fa-comment" style="color: #202124;"></i>
+                            <span class="replyCount" style="color: #202124; margin-left: 5px;">{{ $tweet->replies->count() }}</span>
                         </button>
 
                         {{-- いいねボタン  --}}

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -37,37 +37,52 @@
                     </p>
                 </a>
                 <div style="display: flex; align-items: center;">
-                    {{-- リプライボタン --}}
-                    <div style="margin-left: 12px">
-                        @if($tweet->isFavorite($tweet->id, auth()->id()))
-                            {{-- いいね済 --}}
-                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                                <i class="fa-regular fa-comment"></i>
-                            </button>
-                        @else
-                            {{-- いいね未 --}}
-                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                                <i class="fa-regular fa-comment"></i>
-                            </button>
-                        @endif
-                    </div>
-                    {{-- いいねボタン  --}}
-                    <div style="margin-left: 20px">
-                        @if($tweet->isFavorite($tweet->id, auth()->id()))
+                    {{-- リプライボタン(tiriger modal) --}}
+                        <button type="button" class="reply-button btn btn-primary" data-bs-toggle="modal" data-bs-target="#{{ $tweet->id }}" style="background: transparent; border: none; margin-left: 8px">
+                            <i class="fa-regular fa-comment" style="color: #202124;"></i>
+                        </button>
+
+                        {{-- いいねボタン  --}}
+                        <div style="margin-left: 20px">
+                            @if($tweet->isFavorite($tweet->id, auth()->id()))
                             {{-- いいね済 --}}
                             <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-solid fa-heart" style="color: #f91880;"></i>
                                 <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                        @else
+                            @else
                             {{-- いいね未 --}}
                             <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-regular fa-heart" style="color: #202124;"></i>
                                 <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                        @endif
+                            @endif
+                        </div>
                     </div>
                 </div>
+                {{-- Modal --}}
+                <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
+                    @csrf
+                    <div class="modal fade" id="{{ $tweet->id}}" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                            <div class="modal-body">
+                                <div class="mb-3">
+                                    <label for="message-text" class="col-form-label">リプライ</label>
+                                    <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
+                                    @error('body')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                    @enderror
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button class="btn btn-outline-primary" type="submit">{{ __('返信') }}</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </div>
             @endforeach
         </div>

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -47,13 +47,13 @@
                         <div style="margin-left: 20px">
                             @if($tweet->isFavorite($tweet->id, auth()->id()))
                             {{-- いいね済 --}}
-                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                            <button class="favorite-button" fav_val="{{ config('const.fav_val.favorited') }}" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-solid fa-heart" style="color: #f91880;"></i>
                                 <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
                             @else
                             {{-- いいね未 --}}
-                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                            <button class="favorite-button" fav_val="{{ config('const.fav_val.unfavorite') }}" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
                                 <i class="fa-regular fa-heart" style="color: #202124;"></i>
                                 <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -14,6 +14,11 @@
                     {{ session('message') }}
                 </div>
             @endif
+            @if(session('reply'))
+                <div class="alert alert-success">
+                    {{ session('reply') }}
+                </div>
+            @endif
             <div class="card bg-white mb-3">
                 <div class="card-body">
                     <h6 class="card-title">
@@ -24,25 +29,34 @@
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
-                    @if($tweet->isFavorite($tweet->id, auth()->id()))
-                        {{-- いいね済 --}}
-                        <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-solid fa-heart" style="color: #f91880;"></i>
-                            <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                    <div style="display: flex; align-items: center;">
+                        {{-- リプライボタン(tiriger modal) --}}
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" style="background: transparent; border: none;">
+                            <i class="fa-regular fa-comment" style="color: #202124;"></i>
                         </button>
-                    @else
-                        {{-- いいね未 --}}
-                        <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
-                            <i class="fa-regular fa-heart" style="color: #202124;"></i>
-                            <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
-                        </button>
-                        @endif
-                    @can('update', $tweet)
-                        <div class="d-grid d-md-flex justify-content-md-end">
-                            <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
-                                {{ __('編集') }}
+                        {{-- いいねボタン  --}}
+                        <div style="margin-left: 20px">
+                            @if($tweet->isFavorite($tweet->id, auth()->id()))
+                            {{-- いいね済 --}}
+                            <button class="favorite-button" fav_val="1" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-solid fa-heart" style="color: #f91880;"></i>
+                                <span class="favoriteCount" style="color: #f91880; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
                             </button>
-                            <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
+                            @else
+                            {{-- いいね未 --}}
+                            <button class="favorite-button" fav_val="0" style="background: transparent; border: none;" data-tweet-id={{ $tweet->id }}>
+                                <i class="fa-regular fa-heart" style="color: #202124;"></i>
+                                <span class="favoriteCount" style="color: #202124; margin-left: 5px;">{{ $tweet->favorites->count() }}</span>
+                            </button>
+                            @endif
+                        </div>
+                    </div>
+                    @can('update', $tweet)
+                    <div class="d-grid d-md-flex justify-content-md-end">
+                        <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
+                            {{ __('編集') }}
+                        </button>
+                        <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
                             return confirm('本当にツイートを削除してもよろしいですか？');">
                                 @csrf
                                 @method('delete')
@@ -54,6 +68,29 @@
                     @endcan
                 </div>
             </div>
+            {{-- Modal --}}
+            <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
+                @csrf
+                <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                        <div class="modal-body">
+                            <div class="mb-3">
+                                <label for="message-text" class="col-form-label">リプライ</label>
+                                <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
+                                @error('body')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button class="reply-button btn btn-outline-primary">{{ __('返信') }}</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -87,7 +87,7 @@
                 </div>
             </form>
             {{-- リプライ --}}
-            @foreach($replies as $reply)
+            @foreach($tweet->replies as $reply)
             <div class="card bg-white mb-3">
                 <div class="card-body">
                     <h6 class="card-title">

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -25,14 +25,32 @@
                         {{ $tweet->user->display_name }}
                         <span class="text-muted">{{ '@' }}{{ $tweet->user->user_name }}</span>
                         <span class="text-muted">{{ '・' }}{{ $tweet->created_at->format('h:i A · M d, Y') }}</span>
+                        @can('update', $tweet)
+                        <div class="dropdown" style="display: inline-block; float: right;">
+                            <i class="fa-solid fa-ellipsis text-right" data-bs-toggle="dropdown" aria-expanded="false"></i>
+                            <ul class="dropdown-menu">
+                                <li><a class="dropdown-item" href="{{ route('tweet.edit', $tweet) }}">編集</a></li>
+                                <li>
+                                    <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="return confirm('本当にツイートを削除してもよろしいですか?');">
+                                        @csrf
+                                        @method('delete')
+                                        <button type="submit" class=" dropdown-item btn btn-link text-danger">
+                                            {{ __('削除') }}
+                                        </button>
+                                    </form>
+                                </li>
+                            </ul>
+                        </div>
+                        @endcan
                     </h6>
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
                     <div style="display: flex; align-items: center;">
-                        {{-- リプライボタン(tiriger modal) --}}
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" style="background: transparent; border: none;">
+                        {{-- リプライボタン --}}
+                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#reply-modal" style="background: transparent; border: none;">
                             <i class="fa-regular fa-comment" style="color: #202124;"></i>
+                            <span class="replyCount" style="color: #202124; margin-left: 5px;">{{ $tweet->replies->count() }}</span>
                         </button>
                         {{-- いいねボタン  --}}
                         <div style="margin-left: 20px">
@@ -51,42 +69,99 @@
                             @endif
                         </div>
                     </div>
-                    @can('update', $tweet)
-                    <div class="d-grid d-md-flex justify-content-md-end">
-                        <button type="button" class="btn btn-outline-dark me-md-2" onclick="location.href='{{ route('tweet.edit', $tweet) }}'">
-                            {{ __('編集') }}
-                        </button>
-                        <form method='post' action={{ route('tweet.delete', $tweet) }} onsubmit="
-                            return confirm('本当にツイートを削除してもよろしいですか？');">
-                                @csrf
-                                @method('delete')
-                                <button type="submit" class="btn btn-danger mx-2">
-                                    {{ __('削除') }}
-                                </button>
-                            </form>
-                        </div>
-                    @endcan
                 </div>
             </div>
-            {{-- Modal --}}
+            {{-- リプライフォーム --}}
             <form method="POST" action="{{ route('reply.store', $tweet->id) }}">
                 @csrf
-                <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="mb-3">
+                    <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
+                    @error('body')
+                    <span class="invalid-feedback" role="alert">
+                        <strong>{{ $message }}</strong>
+                    </span>
+                        @enderror
+                </div>
+                <div class="d-grid justify-content-md-end mb-3">
+                    <button class="btn btn-outline-primary" type="submit">{{ __('返信') }}</button>
+                </div>
+            </form>
+            {{-- リプライ --}}
+            @foreach($replies as $reply)
+            <div class="card bg-white mb-3">
+                <div class="card-body">
+                    <h6 class="card-title">
+                        {{ $reply->user->display_name }}
+                        <span class="text-muted">{{ '@' }}{{ $reply->user->user_name }}</span>
+                        <span class="text-muted">{{ '・' }}{{ $reply->created_at->format('h:i A · M d, Y') }}</span>
+                        @can('update', $reply)
+                        <div class="dropdown" style="display: inline-block; float: right;">
+                            <i class="fa-solid fa-ellipsis text-right" data-bs-toggle="dropdown" aria-expanded="false"></i>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#edit-reply-modal-{{ $reply->id }}" href="#">編集</a>
+                                </li>
+                                <li>
+                                    <form method='post' action={{ route('reply.delete', $reply->id) }} onsubmit="return confirm('本当にリプライを削除してもよろしいですか?');">
+                                        @csrf
+                                        @method('delete')
+                                        <button type="submit" class=" dropdown-item btn btn-link text-danger">
+                                            {{ __('削除') }}
+                                        </button>
+                                    </form>
+                                </li>
+                            </ul>
+                        </div>
+                        @endcan
+                        {{-- リプライ編集のモーダル --}}
+                        <form method="POST" action="{{ route('reply.update', $reply->id) }}">
+                            @csrf
+                            <div class="modal fade" id="edit-reply-modal-{{ $reply->id }}" tabindex="-1" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                    <div class="modal-body">
+                                        <div class="mb-3">
+                                            <label for="message-text" class="col-form-label">リプライ</label>
+                                            <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body'>{{ $reply->body }}</textarea>
+                                            @error('body')
+                                            <span class="invalid-feedback" role="alert">
+                                                <strong>{{ $message }}</strong>
+                                            </span>
+                                            @enderror
+                                        </div>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button class="reply-button btn btn-outline-primary" name=submit-button>{{ __('返信') }}</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </form>
+                    </h6>
+                    <p class="card-text" style="font-size: 15px">
+                        {{ $reply->body }}
+                    </p>
+                </div>
+            </div>
+            @endforeach
+            {{-- リプライのモーダル --}}
+            <form method="POST" action="{{ route('reply.store', $tweet->id) }}" name="reply">
+                @csrf
+                <div class="modal fade" id="reply-modal" tabindex="-1" aria-hidden="true">
                     <div class="modal-dialog">
                         <div class="modal-content">
                         <div class="modal-body">
                             <div class="mb-3">
                                 <label for="message-text" class="col-form-label">リプライ</label>
-                                <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body' value="{{ old('body') }}"></textarea>
-                                @error('body')
-                                <span class="invalid-feedback" role="alert">
-                                    <strong>{{ $message }}</strong>
-                                </span>
-                                @enderror
-                            </div>
+                                    <textarea class="form-control @error('body') is-invalid @enderror" id="body" rows="3" type="text" name='body'>{{ old('body') }}</textarea>
+                                    @error('body')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                    @enderror
+                             </div>
                         </div>
                         <div class="modal-footer">
-                            <button class="reply-button btn btn-outline-primary">{{ __('返信') }}</button>
+                            <button class="reply-button btn btn-outline-primary" name=submit-button>{{ __('返信') }}</button>
                         </div>
                     </div>
                 </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -30,55 +30,59 @@ Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name
 Route::group(['middleware' => 'auth'], function () {
 
     // マイページ
-    Route::prefix('user/{id}')->group(function () {
+    Route::group(['prefix' => 'user/{id}', 'as' => 'user.'], function () {
         // ユーザー詳細画面の表示
-        Route::get('/', [UserController::class, 'showUserInfo'])->name('user.show');
+        Route::get('/', [UserController::class, 'showUserInfo'])->name('show');
         // ユーザー編集画面の表示
-        Route::get('/edit', [UserController::class, 'edit'])->name('user.edit');
+        Route::get('/edit', [UserController::class, 'edit'])->name('edit');
         // ユーザー情報更新
-        Route::put('/update', [UserController::class, 'update'])->name('user.update');
+        Route::put('/update', [UserController::class, 'update'])->name('update');
         // ユーザー削除
-        Route::delete('/', [UserController::class, 'delete'])->name('user.delete');
+        Route::delete('/', [UserController::class, 'delete'])->name('delete');
     });
 
-    Route::prefix('users')->group(function () {
+    Route::group(['prefix' => 'users', 'as' => 'user.'], function () {
         // ユーザー一覧
-        Route::get('/', [UserController::class, 'getAllUsers'])->name('user.index');
+        Route::get('/', [UserController::class, 'getAllUsers'])->name('index');
         // フォロー
-        Route::post('/follow/{id}', [UserController::class, 'follow'])->name('user.follow');
+        Route::post('/follow/{id}', [UserController::class, 'follow'])->name('follow');
         // フォロー解除
-        Route::post('/unfollow/{id}', [UserController::class, 'unfollow'])->name('user.unfollow');
+        Route::post('/unfollow/{id}', [UserController::class, 'unfollow'])->name('unfollow');
         // フォロー一覧
-        Route::get('/followed', [UserController::class, 'showFollowedUsers'])->name('user.followed');
+        Route::get('/followed', [UserController::class, 'showFollowedUsers'])->name('followed');
         // フォロワー一覧
-        Route::get('/follower', [UserController::class, 'showFollowerUsers'])->name('user.follower');
+        Route::get('/follower', [UserController::class, 'showFollowerUsers'])->name('follower');
     });
 
 
     // ツイート
-    Route::prefix('tweet')->group(function () {
+    Route::group(['prefix' => 'tweet', 'as' => 'tweet.'], function () {
         // ツイート画面の表示
-        Route::get('/create', [TweetController::class, 'create'])->name('tweet.create');
+        Route::get('/create', [TweetController::class, 'create'])->name('create');
         // ツイート保存
-        Route::post('/store', [TweetController::class, 'store'])->name('tweet.store');
+        Route::post('/store', [TweetController::class, 'store'])->name('store');
         // ツイート詳細画面の表示
-        Route::get('/{id}', [TweetController::class, 'findByTweetId'])->name('tweet.show');
+        Route::get('/{id}', [TweetController::class, 'findByTweetId'])->name('show');
         //　ツイート編集画面の表示
-        Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('tweet.edit');
+        Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('edit');
         // ツイート内容更新
-        Route::put('/{id}/update', [TweetController::class, 'update'])->name('tweet.update');
+        Route::put('/{id}/update', [TweetController::class, 'update'])->name('update');
         // ツイート削除
-        Route::delete('/{id}/delete', [TweetController::class, 'delete'])->name('tweet.delete');
+        Route::delete('/{id}/delete', [TweetController::class, 'delete'])->name('delete');
         //　いいね
-        Route::post('/favorite', [FavoriteController::class, 'favorite'])->name('tweet.favorite');
+        Route::post('/favorite', [FavoriteController::class, 'favorite'])->name('favorite');
         // いいね解除
-        Route::post('/unfavorite', [FavoriteController::class, 'unfavorite'])->name('tweet.unfavorite');
+        Route::post('/unfavorite', [FavoriteController::class, 'unfavorite'])->name('unfavorite');
+    });
+
+    // リプライ
+    Route::group(['prefix' => 'tweet', 'as' => 'reply.'], function () {
         // リプライ保存
-        Route::post('/{id}/store', [ReplyController::class, 'store'])->name('reply.store');
+        Route::post('/{id}/store', [ReplyController::class, 'store'])->name('store');
         // リプライ更新
-        Route::post('/{id}/updateReply', [ReplyController::class, 'update'])->name('reply.update');
+        Route::post('/{id}/updateReply', [ReplyController::class, 'update'])->name('update');
         // リプライ削除
-        Route::delete('/{id}/deleteReply', [ReplyController::class, 'delete'])->name('reply.delete');
+        Route::delete('/{id}/deleteReply', [ReplyController::class, 'delete'])->name('delete');
     });
 
     // ツイート一覧

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -75,6 +75,10 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/unfavorite', [FavoriteController::class, 'unfavorite'])->name('tweet.unfavorite');
         // リプライ保存
         Route::post('/{id}/store', [ReplyController::class, 'store'])->name('reply.store');
+        // リプライ更新
+        Route::post('/{id}/updateReply', [ReplyController::class, 'update'])->name('reply.update');
+        // リプライ削除
+        Route::delete('/{id}/deleteReply', [ReplyController::class, 'delete'])->name('reply.delete');
     });
 
     // ツイート一覧

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FavoriteController;
 use App\Models\Favorite;
+use App\Models\Reply;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\Routing\Route as RoutingRoute;
 
@@ -73,6 +74,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/favorite', [FavoriteController::class, 'favorite'])->name('tweet.favorite');
         // いいね解除
         Route::post('/unfavorite', [FavoriteController::class, 'unfavorite'])->name('tweet.unfavorite');
+        // リプライ保存
+        Route::post('/{id}/store', [ReplyController::class, 'store'])->name('reply.store');
     });
 
     // ツイート一覧

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -3,8 +3,7 @@
 use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FavoriteController;
-use App\Models\Favorite;
-use App\Models\Reply;
+use App\Http\Controllers\ReplyController;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\Routing\Route as RoutingRoute;
 

--- a/twitter/storage/debugbar/.gitignore
+++ b/twitter/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
# 課題のリンク
- ツイートへのリプライが表示できる
- リプライを編集・削除できる


# 改修内容
- ツイート詳細ページでリプライ一覧を表示
- ツイートとリプライのuser_idがログインユーザーのidと一致する場合は、オプションボタン及び編集・削除のドロップダウンメニューをを表示
- 編集用のモーダルを表示

# キャプチャ
https://github.com/JoMashiko/twitter-clone/assets/143980390/df498f98-3318-4f3d-8491-34f1d9102215

# 検証内容
- ツイートへのリプライ一覧表示がRepliesテーブルと一致しているか目視で確認
- 編集・削除後にRepliesテーブルが更新されていることを目視で確認