### PR TITLE
画像投稿機能の追加

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Tweet\CreateTweetRequest;
 use App\Http\Requests\Tweet\UpdateRequest;
+use App\Models\Image;
 use App\Models\Tweet;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
@@ -18,10 +19,12 @@ class TweetController extends Controller
      * コンストラクタ
      */
     private $tweetModel;
+    private $imageModel;
 
-    public function __construct(Tweet $tweetModel)
+    public function __construct(Tweet $tweetModel, Image $imageModel)
     {
         $this->tweetModel = $tweetModel;
+        $this->imageModel = $imageModel;
     }
 
     /**
@@ -47,6 +50,19 @@ class TweetController extends Controller
             $tweetParam = $request->validated();
             $this->tweetModel->store($tweetParam, $userId);
 
+            // ディレクトリ名
+            $dir = 'images';
+            // アップロードされたファイル名を取得
+            $uploadedFile = $request->file('image');
+
+            if (isset($uploadedFile)) {
+                // ファイル名を取得して保存
+                $fileName = $uploadedFile->getClientOriginalName();
+                $uploadedFile->storeAs('public/' . $dir, $fileName);
+                $tweetId = $this->tweetModel->id;
+                $image_path = 'storage/' . $dir . '/' . $fileName;
+                $this->imageModel->store($tweetId, $image_path);
+            }
             return redirect()->route('tweet.index')->with('success', 'ツイートが保存されました');
         } catch (Exception $e) {
             Log::error($e);

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -49,20 +49,19 @@ class TweetController extends Controller
             $userId = Auth::id();
             $tweetParam = $request->validated();
             $this->tweetModel->store($tweetParam, $userId);
+            $tweetId = $this->tweetModel->id;
 
-            // ディレクトリ名
-            $dir = 'images';
-            // アップロードされたファイル名を取得
             $uploadedFile = $request->file('image');
 
             if (isset($uploadedFile)) {
-                // ファイル名を取得して保存
+                $dirName = 'images';
                 $fileName = $uploadedFile->getClientOriginalName();
-                $uploadedFile->storeAs('public/' . $dir, $fileName);
-                $tweetId = $this->tweetModel->id;
-                $image_path = 'storage/' . $dir . '/' . $fileName;
-                $this->imageModel->store($tweetId, $image_path);
+                $imagePath = 'storage/' . $dirName . '/' . $fileName;
+
+                $this->imageModel->saveImage($uploadedFile, $dirName, $fileName);
+                $this->imageModel->store($tweetId, $imagePath);
             }
+
             return redirect()->route('tweet.index')->with('success', 'ツイートが保存されました');
         } catch (Exception $e) {
             Log::error($e);

--- a/twitter/app/Http/Requests/Tweet/CreateTweetRequest.php
+++ b/twitter/app/Http/Requests/Tweet/CreateTweetRequest.php
@@ -24,7 +24,17 @@ class CreateTweetRequest extends FormRequest
     public function rules()
     {
         return [
-            'body' => 'required|string|max:140'
+            'body' => 'required|string|max:140',
+            'image' => 'image|mimes:jpeg,png,gif',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            "body.max" => "ツイートは140文字以下にしてください。",
+            "image.image" => "指定されたファイルが画像ではありません。",
+            "image.mines" => "指定された拡張子（PNG/JPG/GIF）ではありません。",
         ];
     }
 }

--- a/twitter/app/Models/Image.php
+++ b/twitter/app/Models/Image.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Image extends Model
+{
+    use HasFactory;
+
+    protected $table = 'images';
+
+    protected $fillable = ['tweet_id', 'user_id', 'image_path'];
+
+    /**
+     * 画像のパスを保存する
+     *
+     * @param integer $tweetId
+     * @param string $image_path
+     * @return void
+     */
+    public function store(int $tweetId, string $image_path): void
+    {
+        $this->tweet_id = $tweetId;
+        $this->image_path = $image_path;
+        $this->save();
+    }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function tweet()
+    {
+        return $this->belongsTo(Tweet::class);
+    }
+}

--- a/twitter/app/Models/Image.php
+++ b/twitter/app/Models/Image.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
 
 class Image extends Model
 {
@@ -14,16 +15,29 @@ class Image extends Model
     protected $fillable = ['tweet_id', 'user_id', 'image_path'];
 
     /**
-     * 画像のパスを保存する
+     * 画像を保存する
+     *
+     * @param UploadedFile $uploadedFile
+     * @param string $dirName
+     * @param string $fileName
+     * @return void
+     */
+    public function saveImage(UploadedFile $uploadedFile, string $dirName, string $fileName): void
+    {
+        $uploadedFile->storeAs('public/' . $dirName, $fileName);
+    }
+
+    /**
+     * 画像のパスをデータベースに保存する
      *
      * @param integer $tweetId
      * @param string $image_path
      * @return void
      */
-    public function store(int $tweetId, string $image_path): void
+    public function store(int $tweetId, string $imagePath): void
     {
         $this->tweet_id = $tweetId;
-        $this->image_path = $image_path;
+        $this->image_path = $imagePath;
         $this->save();
     }
 

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -17,9 +17,7 @@ class Reply extends Model
     /**
      * リプライを保存する
      *
-     * @param int $tweetId
-     * @param integer $userId
-     * @param array $reply
+     * @param array $replyParam
      * @return void
      */
     public function store(array $replyParam): void

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -134,4 +134,14 @@ class Tweet extends Model
     {
         return $this->hasMany(Reply::class);
     }
+
+    /**
+     * リレーション
+     *
+     * @return void
+     */
+    public function images()
+    {
+        return $this->hasMany(Image::class);
+    }
 }

--- a/twitter/database/migrations/2023_11_15_145016_create_images_table.php
+++ b/twitter/database/migrations/2023_11_15_145016_create_images_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tweet_id')->comment('ツイートID');
+            $table->string('image_path');
+            $table->timestamps();
+
+            $table->foreign('tweet_id')
+                ->references('id')->on('tweets')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('images');
+    }
+};

--- a/twitter/resources/views/tweet/create.blade.php
+++ b/twitter/resources/views/tweet/create.blade.php
@@ -21,7 +21,13 @@
                              @enderror
                         </div>
 
-                        <input type="file" name="image">
+                        <input type="file" class="@error('image') is-invalid @enderror" name="image" value="{{ old('image') }}">
+
+                        @error('image')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                         
                         <div class="d-grid justify-content-md-end">
                             <button class="btn btn-primary" type="submit">{{ __('投稿') }}</button>

--- a/twitter/resources/views/tweet/create.blade.php
+++ b/twitter/resources/views/tweet/create.blade.php
@@ -8,7 +8,7 @@
                 <div class="card-header">{{ __('ツイート') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('tweet.store') }}">
+                    <form method="POST" action="{{ route('tweet.store') }}" enctype="multipart/form-data">
                         @csrf
 
                         <div class="mb-3">
@@ -21,6 +21,8 @@
                              @enderror
                         </div>
 
+                        <input type="file" name="image">
+                        
                         <div class="d-grid justify-content-md-end">
                             <button class="btn btn-primary" type="submit">{{ __('投稿') }}</button>
                         </div>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -46,6 +46,11 @@
                     <p class="card-text">
                         {{ $tweet->body }}
                     </p>
+                    <p>
+                        @foreach ($tweet->images as $image)
+                            <img src="{{ asset($image->image_path) }}" alt="Image">
+                        @endforeach
+                    </p>
                     <div style="display: flex; align-items: center;">
                         {{-- リプライボタン --}}
                         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#reply-modal" style="background: transparent; border: none;">


### PR DESCRIPTION
# 改修内容
- ツイート投稿フォームにアップロードボタンを追加
- 詳細画面で画像を表示

# キャプチャ

https://github.com/JoMashiko/twitter-clone/assets/143980390/516d415b-146e-4209-ac30-eff340bd92d7


# 検証内容
- imageテーブルに画像の保存先のパスが保存されていることを確認